### PR TITLE
add the passed Args in the Prg redirect

### DIFF
--- a/Controller/Component/PrgComponent.php
+++ b/Controller/Component/PrgComponent.php
@@ -16,7 +16,12 @@ class PrgComponent extends Component {
 			return;
 		}
 
-		$controller->redirect(['?' => $request->data]);
+		$passArgs = '';
+		if (isset($request->params['pass']) && !empty($request->params['pass'])):
+			$passArgs = implode('/', $request->params['pass']);
+		endif;
+
+		$controller->redirect([$passArgs, '?' => $request->data]);
 	}
 
 }


### PR DESCRIPTION
Needed this on a page like `/controller/action/1`, the passed arg `1` was always erased with the Prg Component
