### PR TITLE
add passed args in Prg Component

### DIFF
--- a/Controller/Component/PrgComponent.php
+++ b/Controller/Component/PrgComponent.php
@@ -22,7 +22,12 @@ class PrgComponent extends Component {
 			return;
 		}
 
-		$controller->redirect(['?' => $request->data]);
+		$passArgs = '';
+		if (isset($request->params['pass']) && !empty($request->params['pass'])) {
+			$passArgs = implode('/', $request->params['pass']);
+		}
+
+		$controller->redirect([$passArgs, '?' => $request->data]);
 	}
 
 }


### PR DESCRIPTION
I already made this change here #1, but erased it.
I think it's useful when the Prg Component is used in pages like /controller/action/1, the passed arg 1 is always erased with the Prg Component.
