### PR TITLE
Keep search settings / Multiple search values

### DIFF
--- a/Controller/Component/PrgComponent.php
+++ b/Controller/Component/PrgComponent.php
@@ -26,6 +26,7 @@ class PrgComponent extends Component
         $request = $controller->request;
 
         if (!$request->is('post')) {
+            $request->data = $request->query;
             return;
         }
 

--- a/Type/Value.php
+++ b/Type/Value.php
@@ -2,7 +2,6 @@
 namespace Search\Type;
 
 use Cake\ORM\Query;
-use Cake\Database\Expression\TupleComparison;
 
 class Value extends Base
 {
@@ -19,13 +18,7 @@ class Value extends Base
         }
 
         $this->query()->andWhere(function($e) {
-            // $field = $this->field();
-
-            // if (is_array($field)) {
-            //     return new TupleComparison($field, $this->value());
-            // }
-
-            return $e->eq($this->field(), $this->value());
+            return $e->in($this->field(), $this->value());
         });
 
     }


### PR DESCRIPTION
Two changes here:

1. If you don't provide the search values as post data, you will lose the search form data.
2. If you use `in()` instead of `eq()` you can provide multiple values.