### PR TITLE
Fixing PrgComponent by making it short-sircuit the response cycle

### DIFF
--- a/src/Controller/Component/PrgComponent.php
+++ b/src/Controller/Component/PrgComponent.php
@@ -10,7 +10,7 @@ class PrgComponent extends Component
      * Checks if the current request has posted data and redirects the users
      * to the same action after converting the post data into GET params
      *
-     * @return null|Cake\Network\Response
+     * @return void|Cake\Network\Response
      */
     public function startup()
     {

--- a/src/Controller/Component/PrgComponent.php
+++ b/src/Controller/Component/PrgComponent.php
@@ -6,14 +6,13 @@ use Cake\Event\Event;
 
 class PrgComponent extends Component
 {
-
     /**
-     * Initialize properties.
+     * Checks if the current request has posted data and redirects the users
+     * to the same action after converting the post data into GET params
      *
-     * @param array $config The config data.
-     * @return void
+     * @return null|Cake\Network\Response
      */
-    public function initialize(array $config)
+    public function startup()
     {
         $controller = $this->_registry->getController();
         $request = $controller->request;

--- a/tests/TestCase/Controller/Component/PrgComponentTest.php
+++ b/tests/TestCase/Controller/Component/PrgComponentTest.php
@@ -30,7 +30,7 @@ class SearchComponentTest extends TestCase
         $expected = ['foo' => 'bar'];
         $this->Controller->request->query = $expected;
 
-        $this->Prg->initialize([]);
+        $this->Prg->startup();
         $this->assertEquals($expected, $this->Controller->request->data);
     }
 
@@ -44,7 +44,7 @@ class SearchComponentTest extends TestCase
         $this->Controller->request->data = ['foo' => 'bar'];
         $this->Controller->request->env('REQUEST_METHOD', 'POST');
 
-        $response = $this->Prg->initialize([]);
+        $response = $this->Prg->startup();
         $this->assertEquals('http://localhost/index/pass?foo=bar', $response->header()['Location']);
     }
 }


### PR DESCRIPTION
Previously it was letting the full request to complete before doing
the redirect. This is becuase it is not allowed to return a response
from the initialize() method