### PR TITLE
fix copy/paste errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ public function searchConfiguration()
     ->like('q', [
         'before' => true,
         'after' => true,
-        'field' => [$this->aliasField('title'), $this->aliasField('title')]
+        'field' => [$this->aliasField('title'), $this->aliasField('content')]
     ]);
     return $search;
 }
@@ -64,7 +64,7 @@ public function initialize(array $config)
 ```php
 public function index()
 {
-    $query = $this->Countries
+    $query = $this->Articles
         ->find('search', $this->Articles->filterParams($this->request->query))
         ->where(['title !=' => null])
         ->order(['Article.id' => 'asc'])


### PR DESCRIPTION
Remove Country stuff left over from 77f3196f0d01beed5f6a8b4d0c80df361fbac009;
make Usage "like" fields match the documented `title` and `content`