### PR TITLE
Updated the Like and Compare type to use a Comparison expression

### DIFF
--- a/src/Model/Filter/Compare.php
+++ b/src/Model/Filter/Compare.php
@@ -1,6 +1,7 @@
 <?php
 namespace Search\Model\Filter;
 
+use Cake\Database\Expression\Comparison;
 use Cake\ORM\Query;
 
 class Compare extends Base
@@ -40,10 +41,14 @@ class Compare extends Base
             throw new \InvalidArgumentException(sprintf('The operator %s is invalid!', $this->config('operator')));
         }
         foreach ($this->fields() as $field) {
-            $left = $field . ' ' . $this->config('operator');
-            $right = $this->value();
+            $columnType = 'string';
 
-            $conditions[] = [$left => $right];
+            if (is_string($field)) {
+                $columnExists = $this->manager()->table()->schema()->column($field);
+                $columnType = (!$columnExists) ? $this->manager()->table()->schema()->columnType($field) : 'string';
+            }
+
+            $conditions[] = new Comparison($field, $this->value(), $columnType, $this->config('operator'));;
         }
 
         $this->query()->andWhere($conditions);

--- a/src/Model/Filter/Compare.php
+++ b/src/Model/Filter/Compare.php
@@ -48,7 +48,7 @@ class Compare extends Base
                 $columnType = (!$columnExists) ? $this->manager()->table()->schema()->columnType($field) : 'string';
             }
 
-            $conditions[] = new Comparison($field, $this->value(), $columnType, $this->config('operator'));;
+            $conditions[] = new Comparison($field, $this->value(), $columnType, $this->config('operator'));
         }
 
         $this->query()->andWhere($conditions);

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -41,7 +41,7 @@ class Like extends Base
 
             $value = $this->_wildCards($this->value());
 
-            $conditions[] = new Comparison($field, $value, $columnType, 'LIKE');;
+            $conditions[] = new Comparison($field, $value, $columnType, 'LIKE');
         }
 
         $this->query()->andWhere([$this->config('mode') => $conditions]);

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -43,7 +43,7 @@ class Like extends Base
 
             $value = $this->_wildCards($this->value());
 
-            $conditions[] = new Comparison($field, $value, $columnType, 'LIKE');
+            $conditions[] = new Comparison($field, $value, $columnType, $this->config('comparison'));
         }
 
         $this->query()->andWhere([$this->config('mode') => $conditions]);

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -1,6 +1,7 @@
 <?php
 namespace Search\Model\Filter;
 
+use Cake\Database\Expression\Comparison;
 use Cake\ORM\Query;
 
 class Like extends Base
@@ -31,10 +32,16 @@ class Like extends Base
 
         $conditions = [];
         foreach ($this->fields() as $field) {
-            $left = $field . ' ' . $this->config('comparison');
-            $right = $this->_wildCards($this->value());
+            $columnType = 'string';
 
-            $conditions[] = [$left => $right];
+            if (is_string($field)) {
+                $columnExists = $this->manager()->table()->schema()->column($field);
+                $columnType = (!$columnExists) ? $this->manager()->table()->schema()->columnType($field) : 'string';
+            }
+
+            $value = $this->_wildCards($this->value());
+
+            $conditions[] = new Comparison($field, $value, $columnType, 'LIKE');;
         }
 
         $this->query()->andWhere([$this->config('mode') => $conditions]);

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -35,8 +35,10 @@ class Like extends Base
             $columnType = 'string';
 
             if (is_string($field)) {
-                $columnExists = $this->manager()->table()->schema()->column($field);
-                $columnType = (!$columnExists) ? $this->manager()->table()->schema()->columnType($field) : 'string';
+                $scheme = $this->manager()->table()->schema();
+
+                $columnExists = $scheme->column($field);
+                $columnType = (!$columnExists) ? $scheme->columnType($field) : 'string';
             }
 
             $value = $this->_wildCards($this->value());

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -30,5 +30,17 @@ class ArticlesFixture extends TestFixture
             'created' => '2012-12-12 12:12:12',
             'modified' => '2013-01-01 11:11:11',
         ],
+        [
+            'id' => '2',
+            'title' => 'Another test title',
+            'created' => '2014-11-01 21:12:42',
+            'modified' => '2015-08-12 11:43:12',
+        ],
+        [
+            'id' => '3',
+            'title' => 'Already the third article!',
+            'created' => '1988-12-12 12:12:12',
+            'modified' => '2000-01-01 11:11:11',
+        ],
     ];
 }

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -1,0 +1,54 @@
+<?php
+namespace Search\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class UsersFixture extends TestFixture
+{
+
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'string', 'null' => false, 'length' => 36],
+        'username' => ['type' => 'string', 'null' => false, 'default' => null],
+        'firstname' => ['type' => 'string', 'null' => false, 'default' => null],
+        'lastname' => ['type' => 'string', 'null' => false, 'default' => null],
+        'created' => ['type' => 'datetime', 'null' => true, 'default' => null],
+        'modified' => ['type' => 'datetime', 'null' => true, 'default' => null],
+    ];
+
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'id' => '1',
+            'username' => 'UserTest',
+            'firstname' => 'User',
+            'lastname' => 'Test',
+            'created' => '2012-12-12 12:12:12',
+            'modified' => '2013-01-01 11:11:11',
+        ],
+        [
+            'id' => '2',
+            'username' => 'TestUser',
+            'firstname' => 'Test',
+            'lastname' => 'User',
+            'created' => '2014-11-01 21:12:42',
+            'modified' => '2015-08-12 11:43:12',
+        ],
+        [
+            'id' => '3',
+            'username' => 'ASecondUser',
+            'firstname' => 'Second',
+            'lastname' => 'User',
+            'created' => '2014-11-01 21:12:42',
+            'modified' => '2015-08-12 11:43:12',
+        ]
+    ];
+}

--- a/tests/TestCase/Model/Filter/ValueTest.php
+++ b/tests/TestCase/Model/Filter/ValueTest.php
@@ -2,12 +2,10 @@
 namespace Search\Test\TestCase\Model\Filter;
 
 use Cake\Core\Configure;
-use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Search\Manager;
-use Search\Model\Filter\Base;
 use Search\Model\Filter\Value;
 
 class ValueTest extends TestCase
@@ -25,10 +23,20 @@ class ValueTest extends TestCase
     public function testProcess()
     {
         $articles = TableRegistry::get('Articles');
+
         $manager = new Manager($articles);
         $value = new Value('title', $manager);
-        $value->args(['title' => ['test']]);
+        $value->args(['title' => ['Test title one']]);
         $value->query($articles->find());
-        $result = $value->process();
+        $value->process();
+
+        $this->assertEquals(1, $value->query()->count());
+
+        $value = new Value('title', $manager);
+        $value->args(['title' => ['Test title one', 'Already the third article!']]);
+        $value->query($articles->find());
+        $value->process();
+
+        $this->assertEquals(2, $value->query()->count());
     }
 }

--- a/tests/TestCase/Type/CompareTest.php
+++ b/tests/TestCase/Type/CompareTest.php
@@ -1,0 +1,47 @@
+<?php
+namespace Search\Test\TestCase\Type;
+
+use Cake\Core\Configure;
+use Cake\Database\Expression\BetweenExpression;
+use Cake\Database\Expression\FunctionExpression;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use Search\Manager;
+use Search\Type\Compare;
+
+class CompareTest extends TestCase
+{
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.Search.Articles'
+    ];
+
+    public function testProcess()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+
+        $value = new Compare('created', $manager, [
+            'operator' => '>'
+        ]);
+        $value->args(['created' => '2012-12-12 12:12:12']);
+        $value->query($articles->find());
+        $value->process();
+
+        $this->assertEquals(1, $value->query()->count());
+
+        $value = new Compare('created', $manager, [
+            'operator' => '>='
+        ]);
+        $value->args(['created' => '2012-12-12 12:12:12']);
+        $value->query($articles->find());
+        $value->process();
+
+        $this->assertEquals(2, $value->query()->count());
+    }
+}

--- a/tests/TestCase/Type/LikeTest.php
+++ b/tests/TestCase/Type/LikeTest.php
@@ -1,0 +1,127 @@
+<?php
+namespace Search\Test\TestCase\Type;
+
+use Cake\Core\Configure;
+use Cake\Database\Expression\FunctionExpression;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use Search\Manager;
+use Search\Type\Like;
+
+class LikeTest extends TestCase
+{
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.Search.Users'
+    ];
+
+    public function testProcess()
+    {
+        $users = TableRegistry::get('Users');
+        $manager = new Manager($users);
+
+        $value = new Like('username', $manager, [
+            'before' => true,
+            'after' => true,
+            'field' => [
+                $users->aliasField('username')
+            ]
+        ]);
+        $value->args(['username' => 'erTe']);
+        $value->query($users->find());
+        $value->process();
+
+        $this->assertEquals(1, $value->query()->count());
+
+        $value = new Like('username', $manager, [
+            'field' => [
+                $users->aliasField('username')
+            ]
+        ]);
+        $value->args(['username' => 'UserTest']);
+        $value->query($users->find());
+        $value->process();
+
+        $this->assertEquals(1, $value->query()->count());
+
+        $value = new Like('username', $manager, [
+            'before' => true,
+            'field' => [
+                $users->aliasField('username')
+            ]
+        ]);
+        $value->args(['username' => 'Test']);
+        $value->query($users->find());
+        $value->process();
+
+        $this->assertEquals(1, $value->query()->count());
+
+        $value = new Like('username', $manager, [
+            'before' => true,
+            'after' => true,
+            'field' => [
+                $users->aliasField('username')
+            ]
+        ]);
+        $value->args(['username' => 'Test']);
+        $value->query($users->find());
+        $value->process();
+
+        $this->assertEquals(2, $value->query()->count());
+    }
+
+    public function testProcessWithFunctionExpression()
+    {
+        $users = TableRegistry::get('Users');
+        $manager = new Manager($users);
+
+        $concatExpression = new FunctionExpression('CONCAT', [
+            $users->aliasField('firstname') => 'literal',
+            ' ',
+            $users->aliasField('lastname') => 'literal'
+        ]);
+
+        $value = new Like('name', $manager, [
+            'before' => true,
+            'after' => true,
+            'field' => [
+                $concatExpression
+            ]
+        ]);
+        $value->args(['name' => 'Test User']);
+        $value->query($users->find());
+        $value->process();
+
+        $this->assertEquals(1, $value->query()->count());
+
+        $value = new Like('name', $manager, [
+            'before' => true,
+            'after' => true,
+            'field' => [
+                $concatExpression
+            ]
+        ]);
+        $value->args(['name' => 'User']);
+        $value->query($users->find());
+        $value->process();
+
+        $this->assertEquals(3, $value->query()->count());
+
+        $value = new Like('name', $manager, [
+            'after' => true,
+            'field' => [
+                $concatExpression
+            ]
+        ]);
+        $value->args(['name' => 'Test']);
+        $value->query($users->find());
+        $value->process();
+
+        $this->assertEquals(1, $value->query()->count());
+    }
+}


### PR DESCRIPTION
This adds support for `ExpressionInterfaces` as field which, wasn't possible before due the string concate.
It uses a `Comparison`. The `columnType` is received from the `$field` when this `$field` is a `string`. When the `$field` isn't a `string`, we expect the `columnType` to be a `string` (defaults).

@Marlinc 