### PR TITLE
Updated the callback's  reference object

### DIFF
--- a/src/Type/Callback.php
+++ b/src/Type/Callback.php
@@ -17,6 +17,6 @@ class Callback extends Base
             return;
         }
 
-        call_user_func($this->config('callback'), $this->query(), $this->args(), $this);
+        call_user_func([$this->manager()->table(), $this->config('name')], $this->query(), $this->args(), $this);
     }
 }


### PR DESCRIPTION
The name of the callback is `$this->config('name')` instead of `$this->config('callback')`, and it should point to the correct table, so i just added the reference of the table and the correct name with:

```
[$this->manager()->table(), $this->config('name')]
```