### PR TITLE
"0" should not be considered as empty.

### DIFF
--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -135,7 +135,10 @@ abstract class Base
     public function skip()
     {
         return !$this->present() ||
-            ($this->filterEmpty() && empty($this->_args[$this->name()]));
+            ($this->filterEmpty() &&
+                empty($this->_args[$this->name()]) &&
+                !is_numeric($this->_args[$this->name()])
+            );
     }
 
     /**

--- a/tests/TestCase/Model/Filter/BaseTest.php
+++ b/tests/TestCase/Model/Filter/BaseTest.php
@@ -1,0 +1,40 @@
+<?php
+namespace Search\Test\TestCase\Model\Filter;
+
+use Cake\TestSuite\TestCase;
+use Search\Manager;
+use Search\Model\Filter\Base;
+
+class Filter extends Base
+{
+
+    public function process()
+    {
+    }
+}
+
+class BaseTest extends TestCase
+{
+
+    public function testSkip()
+    {
+        $manager = $this->getMock('\Search\Manager', null, [], 'Manager', false);
+        $filter = new Filter(
+            'field',
+            $manager,
+            ['alwaysRun' => true, 'filterEmpty' => true]
+        );
+
+        $filter->args(['field' => '1']);
+        $this->assertFalse($filter->skip());
+
+        $filter->args(['field' => '0']);
+        $this->assertFalse($filter->skip());
+
+        $filter->args(['field' => '']);
+        $this->assertTrue($filter->skip());
+
+        $filter->args(['field' => []]);
+        $this->assertTrue($filter->skip());
+    }
+}


### PR DESCRIPTION
This fixes problem where filter would be skipped when using 'filterEmpty' => true
and value was "0".