### PR TITLE
Update to PrgComponent redirect

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,9 @@
     ],
     "require-dev": {
         "cakephp/cakephp": "~3.0",
-        "friendsofcake/cakephp-test-utilities": "dev-master"
+        "friendsofcake/cakephp-test-utilities": "dev-master",
+        "phpunit/phpunit": "^4.8",
+        "cakephp/cakephp-codesniffer": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Controller/Component/PrgComponent.php
+++ b/src/Controller/Component/PrgComponent.php
@@ -46,9 +46,10 @@ class PrgComponent extends Component
             return null;
         }
         if ($redirect) {
-            return $this->_registry->getController()->redirect(
-                $this->request->params['pass'] + ['?' => $this->request->data]
-            );
+            $parsedUrl = parse_url($this->request->here(false));
+            $url = $parsedUrl['path'] . '?' . http_build_query($this->request->data);
+
+            return $this->_registry->getController()->redirect($url);
         }
         return null;
     }

--- a/tests/TestCase/Controller/Component/PrgComponentTest.php
+++ b/tests/TestCase/Controller/Component/PrgComponentTest.php
@@ -10,6 +10,9 @@ use Search\Controller\Component\PrgComponent;
 
 class SearchComponentTest extends TestCase
 {
+    /**
+     * Pre-test case setup
+     */
     public function setUp()
     {
         parent::setUp();
@@ -25,6 +28,11 @@ class SearchComponentTest extends TestCase
         $this->Prg = new PrgComponent($this->Controller->components());
     }
 
+    /**
+     * Test the initialize method of the component with a get request
+     *
+     * @return void
+     */
     public function testInitializeGet()
     {
         $expected = ['foo' => 'bar'];
@@ -34,37 +42,85 @@ class SearchComponentTest extends TestCase
         $this->assertEquals($expected, $this->Controller->request->data);
     }
 
-    public function testInitializePost()
+    /**
+     * Data provider for testing the Component initialize
+     *
+     * The url must be set to what the Router will return
+     *
+     * @return void
+     */
+    public function providerRequest()
     {
-        $this->Controller->request->params = [
-            'controller' => 'posts',
-            'action' => 'index',
-            'pass' => ['pass']
+        return [
+            [
+                ['controller' => 'posts', 'action' => 'index', 'pass' => ['pass']],
+                ['foo' => 'bar'],
+                '/index/pass',
+                'http://localhost/index/pass?foo=bar'
+            ],
+            [
+                ['controller' => 'Examples', 'action' => 'index'],
+                ['foo' => 'bar'],
+                '/examples',
+                'http://localhost/examples?foo=bar'
+            ],
+            [
+                ['controller' => 'UserAnswers', 'action' => 'index', 'type' => 'open'],
+                ['question' => '', 'category' => 7, 'outcome' => ''],
+                '/user-answers',
+                'http://localhost/user-answers?question=&category=7&outcome='
+            ],
         ];
-        $this->Controller->request->data = ['foo' => 'bar'];
-        $this->Controller->request->env('REQUEST_METHOD', 'POST');
+    }
 
-        $response = $this->Prg->startup();
-        $this->assertEquals('http://localhost/index/pass?foo=bar', $response->header()['Location']);
+    /**
+     * Test the initialize method of the Component with a post method
+     *
+     * @dataProvider providerRequest
+     *
+     * @param  array $requestParams Array of request params
+     * @param  array $requestData   Array of search data
+     * @param  string $url Request url
+     * @param  string $expected     The expected url
+     *
+     * @return void
+     */
+    public function testInitializePost($requestParams, $requestData, $url, $expected)
+    {
+        $request = new Request([
+            'url' => $url,
+            'base' => '/',
+            'params' => $requestParams,
+            'environment' => ['REQUEST_METHOD' => 'POST']
+        ]);
+        $request->data = $requestData;
 
-        $this->Prg->config('actions', false);
-        $response = $this->Prg->startup();
+        $response = $this->getMock('Cake\Network\Response', ['stop']);
+
+        $controller = new Controller($request, $response);
+        $prg = new PrgComponent($controller->components());
+
+        $response = $prg->startup();
+        $this->assertEquals($expected, $response->header()['Location']);
+
+        $prg->config('actions', false);
+        $response = $prg->startup();
         $this->assertEquals(null, $response);
 
-        $this->Prg->config('actions', 'does-not-exist', false);
-        $response = $this->Prg->startup();
+        $prg->config('actions', 'does-not-exist', false);
+        $response = $prg->startup();
         $this->assertEquals(null, $response);
 
-        $this->Prg->config('actions', 'index', false);
-        $response = $this->Prg->startup();
-        $this->assertEquals('http://localhost/index/pass?foo=bar', $response->header()['Location']);
+        $prg->config('actions', 'index', false);
+        $response = $prg->startup();
+        $this->assertEquals($expected, $response->header()['Location']);
 
-        $this->Prg->config('actions', ['index', 'does-not-exist'], false);
-        $response = $this->Prg->startup();
-        $this->assertEquals('http://localhost/index/pass?foo=bar', $response->header()['Location']);
+        $prg->config('actions', ['index', 'does-not-exist'], false);
+        $response = $prg->startup();
+        $this->assertEquals($expected, $response->header()['Location']);
 
-        $this->Prg->config('actions', ['does-not-exist'], false);
-        $response = $this->Prg->startup();
+        $prg->config('actions', ['does-not-exist'], false);
+        $response = $prg->startup();
         $this->assertEquals(null, $response);
     }
 }


### PR DESCRIPTION
This update is to try and fix a bug detailed in #67 which I encountered when trying to redirect using named routes with no fallback routing.

I have updated the component to try and just 'copy' the existing url and append the query string, rather than trying to build a cake url array. This has proved successful in my specific use-case.

I've also updated the corresponding test case. I've had to make a few changes to it, such as putting the initialisation of the Component into the test case, so that the Request can be changed depending on the data from the newly created dataProvider method.

This should allow the test to expand further and easier in the future, if, for example, the test were to include some routing as well, the extra cases can be added.

I've also updated the `composer` file to include `phpunit` which seemed to be missing, as I needed to run the test suite.