### PR TITLE
fallback to like

### DIFF
--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -1,6 +1,7 @@
 <?php
 namespace Search\Model\Filter;
 
+use Cake\Database\Driver\Postgres;
 use Cake\ORM\Query;
 
 class Like extends Base
@@ -27,6 +28,11 @@ class Like extends Base
     {
         if ($this->skip()) {
             return;
+        }
+
+        $driver = $this->query()->connection()->driver();
+        if (!$driver instanceof Postgres) {
+            $this->config('comparison', 'LIKE');
         }
 
         $conditions = [];

--- a/tests/TestCase/Model/Filter/LikeTest.php
+++ b/tests/TestCase/Model/Filter/LikeTest.php
@@ -2,6 +2,7 @@
 namespace Search\Test\TestCase\Model\Filter;
 
 use Cake\Core\Configure;
+use Cake\Database\Driver\Postgres;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -40,6 +41,13 @@ class LikeTest extends TestCase
         $value->process();
 
         $sql = $value->query()->sql();
-        $this->assertEquals(1, preg_match('/WHERE title ilike/', $sql));
+
+        $driver = $value->query()->connection()->driver();
+
+        if ($driver instanceof Postgres) {
+            $this->assertEquals(1, preg_match('/WHERE title ilike/', $sql));
+        } else {
+            $this->assertEquals(1, preg_match('/WHERE title like/', $sql));
+        }
     }
 }


### PR DESCRIPTION
We have a postgres application but we also want to check against mysql with travis. If we use ILIKE, the test cases will fail for mysql. I think it would be nice to have an auto fallback to LIKE if ILIKE isn't available.