### PR TITLE
Fix query string building.

### DIFF
--- a/src/Controller/Component/PrgComponent.php
+++ b/src/Controller/Component/PrgComponent.php
@@ -55,9 +55,11 @@ class PrgComponent extends Component
             }
 
             list($url) = explode('?', $this->request->here(false));
-            return $this->_registry->getController()->redirect(
-                $url . '?' . http_build_query($params)
-            );
+            $queryString = http_build_query($params);
+            if ($queryString !== '') {
+                $url .= '?' . $queryString;
+            }
+            return $this->_registry->getController()->redirect($url);
         }
         return null;
     }


### PR DESCRIPTION
Fixes the building of the url when query strings are not present

Currently

    /controller-name/search?

With the fix:

    /controller-name/search