### PR TITLE
Add char config for LIKE wildcards.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ class ExampleTable extends Table {
 
 ### Controller class
 In order for the Search plugin to work it will need to process the query params
-which are passed in your url. So you will need to edit your `index` method to
-accomodate this.
+which are passed in your URL. So you will need to edit your `index` method to
+accommodate this.
 
 ```php
 public function index()
@@ -177,7 +177,7 @@ could filter your articles using the following.
 
 Would filter your list of articles to any article with "cakephp" in the `title`
 or `content` field. You might choose to make a `get` form which posts the filter
-directly to the url, but if you're using the `Search.Prg` component, you'll want
+directly to the URL, but if you're using the `Search.Prg` component, you'll want
 to use `POST`.
 
 ### Creating your form

--- a/src/Controller/Component/PrgComponent.php
+++ b/src/Controller/Component/PrgComponent.php
@@ -74,6 +74,6 @@ class PrgComponent extends Component
         if (is_string($actions)) {
             $actions = [$actions];
         }
-        return in_array($this->request->action, $actions);
+        return in_array($this->request->action, $actions, true);
     }
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -87,7 +87,7 @@ class Manager
     /**
      * Sets or gets the filter collection name.
      *
-     * @param string $name Name of the active filter collection to set.
+     * @param string|null $name Name of the active filter collection to set.
      * @return mixed Returns $this or the name of the active collection if no $name was provided.
      */
     public function collection($name = null)

--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -81,7 +81,7 @@ class SearchBehavior extends Behavior
      */
     public function searchManager()
     {
-        if (empty($this->_manager)) {
+        if ($this->_manager === null) {
             $this->_manager = new Manager($this->_table);
         }
         return $this->_manager;

--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -90,7 +90,7 @@ class SearchBehavior extends Behavior
     /**
      * Gets all filters from the search manager.
      *
-     * @return array An array of filters for the defined fields.
+     * @return \Search\Model\Filter\Base[] An array of filters for the defined fields.
      */
     protected function _getAllFilters()
     {

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -64,7 +64,7 @@ abstract class Base
             'filterEmpty' => false
         ];
 
-        $this->config(array_merge($defaults, $config));
+        $this->config($config + $defaults);
     }
 
     /**
@@ -154,8 +154,8 @@ abstract class Base
     /**
      * Get / Set the args.
      *
-     * @param array $value Value.
-     * @return void|array
+     * @param array|null $value Value.
+     * @return array|null
      */
     public function args(array $value = null)
     {
@@ -169,8 +169,8 @@ abstract class Base
     /**
      * Get / Set the validation rules.
      *
-     * @param array $value Value.
-     * @return void|array
+     * @param array|null $value Value.
+     * @return array|null
      */
     public function validate(array $value = null)
     {
@@ -197,7 +197,7 @@ abstract class Base
     /**
      * Get / Set the query object.
      *
-     * @param \Cake\ORM\Query $value Value.
+     * @param \Cake\ORM\Query|null $value Value.
      * @return void|\Cake\ORM\Query
      */
     public function query(Query $value = null)

--- a/src/Model/Filter/Compare.php
+++ b/src/Model/Filter/Compare.php
@@ -34,7 +34,7 @@ class Compare extends Base
         }
 
         $conditions = [];
-        if (!in_array($this->config('operator'), $this->_operators)) {
+        if (!in_array($this->config('operator'), $this->_operators, true)) {
             throw new \InvalidArgumentException(sprintf('The operator %s is invalid!', $this->config('operator')));
         }
         foreach ($this->fields() as $field) {

--- a/src/Model/Filter/Finder.php
+++ b/src/Model/Filter/Finder.php
@@ -27,6 +27,6 @@ class Finder extends Base
             return;
         }
 
-        $this->query()->find($this->finder(), $this->args());
+        $this->query()->find($this->finder(), (array)$this->args());
     }
 }

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -88,10 +88,11 @@ class Like extends Base
      * Replace substitutions with original wildcards
      * but first, escape the original wildcards in the text to use them as normal search text
      *
-     * @param string $value
+     * @param string $value Value
      * @return string Value
      */
-    protected function _formatWildCards($value) {
+    protected function _formatWildCards($value)
+    {
         $from = $to = $substFrom = $substTo = [];
         if ($this->config('wildcardAny') !== '%') {
             $from[] = '%';
@@ -113,5 +114,4 @@ class Like extends Base
         }
         return $value;
     }
-
 }

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -71,7 +71,7 @@ class Like extends Base
      * Replace substitutions with original wildcards
      * but first, escape the original wildcards in the text to use them as normal search text
      *
-     * @param string $value Value
+     * @param string $value Value.
      * @return string Value
      */
     protected function _formatWildcards($value)
@@ -89,7 +89,7 @@ class Like extends Base
             $substFrom[] = $this->config('wildcardOne');
             $substTo[] = '_';
         }
-        if (!empty($from)) {
+        if ($from) {
             // Escape first
             $value = str_replace($from, $to, $value);
             // Replace wildcards

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -32,7 +32,7 @@ class Like extends Base
         $conditions = [];
         foreach ($this->fields() as $field) {
             $left = $field . ' ' . $this->config('comparison');
-            $right = $this->_wildCards($this->value());
+            $right = $this->_wildcards($this->value());
 
             $conditions[] = [$left => $right];
         }
@@ -46,22 +46,22 @@ class Like extends Base
      * @param  string $value Value.
      * @return string
      */
-    protected function _wildCards($value)
+    protected function _wildcards($value)
     {
         if (is_array($value)) {
             foreach ($value as $k => $v) {
-                $value[$k] = $this->_wildCards($v);
+                $value[$k] = $this->_wildcards($v);
             }
             return $value;
         }
 
-        $value = $this->_formatWildCards($value);
+        $value = $this->_formatWildcards($value);
         if ($this->config('before')) {
-            $value = $this->_formatWildCards($this->config('wildcardAny')) . $value;
+            $value = $this->_formatWildcards($this->config('wildcardAny')) . $value;
         }
 
         if ($this->config('after')) {
-            $value = $value . $this->_formatWildCards($this->config('wildcardAny'));
+            $value = $value . $this->_formatWildcards($this->config('wildcardAny'));
         }
 
         return $value;
@@ -73,7 +73,7 @@ class Like extends Base
      * @param string $value Value.
      * @return string
      */
-    protected function _escapeWildCards($value)
+    protected function _escapeWildcards($value)
     {
         if (!$this->config('escapeWildcards')) {
             return $value;
@@ -91,7 +91,7 @@ class Like extends Base
      * @param string $value Value
      * @return string Value
      */
-    protected function _formatWildCards($value)
+    protected function _formatWildcards($value)
     {
         $from = $to = $substFrom = $substTo = [];
         if ($this->config('wildcardAny') !== '%') {

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -68,23 +68,6 @@ class Like extends Base
     }
 
     /**
-     * Escape wild cards in value.
-     *
-     * @param string $value Value.
-     * @return string
-     */
-    protected function _escapeWildcards($value)
-    {
-        if (!$this->config('escapeWildcards')) {
-            return $value;
-        }
-
-        $from = ['%', '_'];
-        $to = ['\%', '\_'];
-        return str_replace($from, $to, $value);
-    }
-
-    /**
      * Replace substitutions with original wildcards
      * but first, escape the original wildcards in the text to use them as normal search text
      *

--- a/tests/TestCase/Model/Filter/LikeTest.php
+++ b/tests/TestCase/Model/Filter/LikeTest.php
@@ -49,7 +49,7 @@ class LikeTest extends TestCase
     /**
      * @return void
      */
-    public function testWildCardsEscaping()
+    public function testWildcardsEscaping()
     {
         $articles = TableRegistry::get('Articles');
         $manager = new Manager($articles);

--- a/tests/TestCase/Model/Filter/LikeTest.php
+++ b/tests/TestCase/Model/Filter/LikeTest.php
@@ -114,7 +114,8 @@ class LikeTest extends TestCase
         $filter = new Like(
             'title',
             $manager,
-            ['before' => true, 'after' => true, 'wildcardAny' => '%', 'wildcardOne' => '_']);
+            ['before' => true, 'after' => true, 'wildcardAny' => '%', 'wildcardOne' => '_']
+        );
         $filter->args(['title' => '22% 44_']);
         $filter->query($articles->find());
         $filter->process();

--- a/tests/TestCase/Model/Filter/LikeTest.php
+++ b/tests/TestCase/Model/Filter/LikeTest.php
@@ -111,7 +111,9 @@ class LikeTest extends TestCase
         $articles = TableRegistry::get('Articles');
         $manager = new Manager($articles);
 
-        $filter = new Like('title', $manager,
+        $filter = new Like(
+            'title',
+            $manager,
             ['before' => true, 'after' => true, 'wildcardAny' => '%', 'wildcardOne' => '_']);
         $filter->args(['title' => '22% 44_']);
         $filter->query($articles->find());
@@ -122,5 +124,4 @@ class LikeTest extends TestCase
         $value = $values[':c0']['value'];
         $this->assertEquals('%22% 44_%', $value);
     }
-
 }


### PR DESCRIPTION
Resolves https://github.com/FriendsOfCake/search/issues/82

Classified as bug as currently using wildcard chars as normal text triggers wildcard behavior of DB which is not intended (unless you configure and use those specifically as wildcard chars for your filter).

2nd bug was: When using array input, the LIKE before/after was not working.
There were also no tests for this bug, this is now also fixed.

Also some small code cleanup.