### PR TITLE
Do away with SearchBehavior::filterParams().

### DIFF
--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -64,6 +64,20 @@ class SearchBehavior extends Behavior
     }
 
     /**
+     * Returns search params nested in array with key `_search` for passing as
+     * options to find method.
+     *
+     * @param array $params A key value list of search parameters to use for a search.
+     * @return array
+     * @deprecated 2.0.0 You can directly call find like
+     *   `find('search', ['_search' => $this->request->query])`
+     */
+    public function filterParams($params)
+    {
+        return ['_search' => $params];
+    }
+
+    /**
      * Returns the search filter manager.
      *
      * @return \Search\Manager

--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -3,6 +3,7 @@ namespace Search\Model\Behavior;
 
 use Cake\ORM\Behavior;
 use Cake\ORM\Query;
+use Cake\Utility\Hash;
 use Search\Manager;
 
 class SearchBehavior extends Behavior
@@ -38,40 +39,28 @@ class SearchBehavior extends Behavior
      * Callback fired from the controller.
      *
      * @param Query $query Query.
-     * @param array $options The GET arguments.
+     * @param array $options The options for the find.
+     *   - `_search`: If set it's value will be used as search arguments else
+     *     $options itself will be used.
      * @return \Cake\ORM\Query The Query object used in pagination.
      */
     public function findSearch(Query $query, array $options)
     {
-        if (isset($options['search'])) {
-            $options = $options['search'];
+        $params = $options;
+        if (isset($params['_search'])) {
+            $params = $params['_search'];
         }
 
         $filters = $this->_getAllFilters();
-        foreach ($filters as $config) {
-            $config->args($options);
-            $config->query($query);
-            $config->process();
+        $params = array_intersect_key(Hash::filter($params), $filters);
+
+        foreach ($filters as $filter) {
+            $filter->args($params);
+            $filter->query($query);
+            $filter->process();
         }
 
         return $query;
-    }
-
-    /**
-     * Returns the valid search parameter values according to those that are defined
-     * in the searchConfiguration() method of the table.
-     *
-     * @param array $params a key value list of search parameters to use for a search.
-     * @return array
-     */
-    public function filterParams($params)
-    {
-        foreach ($params as $k => $param) {
-            if (is_string($param) && $param === '') {
-                unset($params[$k]);
-            }
-        }
-        return ['search' => array_intersect_key($params, $this->_getAllFilters())];
     }
 
     /**

--- a/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
@@ -105,6 +105,17 @@ class SearchBehaviorTest extends TestCase
     }
 
     /**
+     * Tests the filterParams method
+     *
+     * @return void
+     */
+    public function testFilterParams()
+    {
+        $result = $this->Articles->filterParams(['foo' => 'bar']);
+        $this->assertEquals(['_search' => ['foo' => 'bar']], $result);
+    }
+
+    /**
      * testSearchManager
      *
      * @return void

--- a/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
@@ -1,8 +1,6 @@
 <?php
 namespace Search\Test\TestCase\Model\Behavior;
 
-use Cake\Core\Configure;
-use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -16,9 +14,9 @@ class ArticlesTable extends Table
         $manager = new Manager($this);
         return $manager
             ->value('foo')
-            ->value('bar', ['filterEmpty' => true])
+            ->like('search', ['filterEmpty' => true])
             ->value('baz')
-            ->value('group');
+            ->value('group', ['field' => 'Articles.group']);
     }
 }
 
@@ -59,37 +57,20 @@ class SearchBehaviorTest extends TestCase
     {
         $queryString = [
             'foo' => 'a',
-            'bar' => 'b',
+            'search' => 'b',
             'group' => 'main'
         ];
 
-        $query = $this->Articles->find('search', ['search' => $queryString]);
+        $query = $this->Articles->find('search', ['_search' => $queryString]);
         $this->assertEquals(3, $query->clause('where')->count());
 
-        $queryString['bar'] = '';
-        $query = $this->Articles->find('search', ['search' => $queryString]);
+        $queryString['search'] = '';
+        $query = $this->Articles->find('search', ['_search' => $queryString]);
         $this->assertEquals(2, $query->clause('where')->count());
 
         $queryString['foo'] = '';
-        $query = $this->Articles->find('search', ['search' => $queryString]);
-        $this->assertEquals(2, $query->clause('where')->count());
-    }
-
-    /**
-     * Tests the filterParams method
-     *
-     * @return void
-     */
-    public function testFilterParams()
-    {
-        $result = $this->Articles->filterParams([
-            'conditions' => 'troll',
-            'foo' => 'a',
-            'bar' => 'b',
-            'group' => 'main'
-        ]);
-        $expected = ['search' => ['foo' => 'a', 'bar' => 'b', 'group' => 'main']];
-        $this->assertEquals($expected, $result);
+        $query = $this->Articles->find('search', ['_search' => $queryString]);
+        $this->assertEquals(1, $query->clause('where')->count());
     }
 
     /**
@@ -101,15 +82,22 @@ class SearchBehaviorTest extends TestCase
     {
         $query = $this->Articles->find('search', [
             'foo' => 'a',
-            'bar' => 'b',
+            'search' => 'b',
             'group' => 'main'
         ]);
         $this->assertEquals(2, $query->clause('where')->count());
 
         $query = $this->Articles->find('search', [
-            'search' => [
+            'foo' => 0,
+            'search' => 'b',
+            'page' => 1
+        ]);
+        $this->assertEquals(2, $query->clause('where')->count());
+
+        $query = $this->Articles->find('search', [
+            '_search' => [
                 'foo' => 'a',
-                'bar' => 'b',
+                'search' => 'b',
                 'group' => 'main'
             ]
         ]);


### PR DESCRIPTION
Rename options key "search" to "_search" to allow using filter named "search".

Refs #54