### PR TITLE
Fixed small error in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ public function index()
     $query = $this->Articles
         // Use the plugins 'search' custom finder and pass in the
         // processed query params
-        ->find('search', ['_search' => $this->request->query])
+        ->find('search', $this->request->query)
         // You can add extra things to the query if you need to
         ->contain(['Comments'])
         ->where(['title IS NOT' => null]);


### PR DESCRIPTION
I'm not sure why the params were hidden under the '_search' key. Without it, the search works. If there is a reason for that, please, let me know.