### PR TITLE
Remove ability to directly pass querystring as find options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ public function index()
     $query = $this->Articles
         // Use the plugins 'search' custom finder and pass in the
         // processed query params
-        ->find('search', ['_search' => $this->request->query])
+        ->find('search', ['search' => $this->request->query])
         // You can add extra things to the query if you need to
         ->contain(['Comments'])
         ->where(['title IS NOT' => null]);

--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -1,6 +1,7 @@
 <?php
 namespace Search\Model\Behavior;
 
+use Exception;
 use Cake\ORM\Behavior;
 use Cake\ORM\Query;
 use Cake\Utility\Hash;
@@ -40,18 +41,20 @@ class SearchBehavior extends Behavior
      *
      * @param Query $query Query.
      * @param array $options The options for the find.
-     *   - `_search`: If set it's value will be used as search arguments else
-     *     $options itself will be used.
+     *   - `search`: Array of search arguments.
      * @return \Cake\ORM\Query The Query object used in pagination.
      */
     public function findSearch(Query $query, array $options)
     {
-        $params = $options;
-        if (isset($params['_search'])) {
-            $params = $params['_search'];
+        if (!isset($options['search'])) {
+            throw new Exception(
+                'Custom finder "search" expects search arguments ' .
+                'to be nested under key "search" in find() options.'
+            );
         }
 
         $filters = $this->_getAllFilters();
+        $params = (array)$options['search'];
         $params = array_intersect_key(Hash::filter($params), $filters);
 
         foreach ($filters as $filter) {
@@ -70,11 +73,11 @@ class SearchBehavior extends Behavior
      * @param array $params A key value list of search parameters to use for a search.
      * @return array
      * @deprecated 2.0.0 You can directly call find like
-     *   `find('search', ['_search' => $this->request->query])`
+     *   `find('search', ['search' => $this->request->query])`
      */
     public function filterParams($params)
     {
-        return ['_search' => $params];
+        return ['search' => $params];
     }
 
     /**

--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -1,10 +1,10 @@
 <?php
 namespace Search\Model\Behavior;
 
-use Exception;
 use Cake\ORM\Behavior;
 use Cake\ORM\Query;
 use Cake\Utility\Hash;
+use Exception;
 use Search\Manager;
 
 class SearchBehavior extends Behavior

--- a/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
@@ -49,7 +49,7 @@ class SearchBehaviorTest extends TestCase
     }
 
     /**
-     * [testFinder description]
+     * Test the custom "search" finder
      *
      * @return void
      */
@@ -61,47 +61,37 @@ class SearchBehaviorTest extends TestCase
             'group' => 'main'
         ];
 
-        $query = $this->Articles->find('search', ['_search' => $queryString]);
+        $query = $this->Articles->find('search', ['search' => $queryString]);
         $this->assertEquals(3, $query->clause('where')->count());
 
         $queryString['search'] = '';
-        $query = $this->Articles->find('search', ['_search' => $queryString]);
+        $query = $this->Articles->find('search', ['search' => $queryString]);
         $this->assertEquals(2, $query->clause('where')->count());
 
         $queryString['foo'] = '';
-        $query = $this->Articles->find('search', ['_search' => $queryString]);
+        $query = $this->Articles->find('search', ['search' => $queryString]);
         $this->assertEquals(1, $query->clause('where')->count());
+
+        $query = $this->Articles->find('search', [
+            'search' => [
+                'foo' => 0,
+                'search' => 'b',
+                'page' => 1
+            ]
+        ]);
+        $this->assertEquals(2, $query->clause('where')->count());
     }
 
     /**
-     * Test the custom "search" finder
+     * testFindSearchException
      *
+     * @expectedException Exception
+     * @expectedExceptionMessage Custom finder "search" expects search arguments to be nested under key "search" in find() options.
      * @return void
      */
-    public function testFindSearch()
+    public function testFindSearchException()
     {
-        $query = $this->Articles->find('search', [
-            'foo' => 'a',
-            'search' => 'b',
-            'group' => 'main'
-        ]);
-        $this->assertEquals(2, $query->clause('where')->count());
-
-        $query = $this->Articles->find('search', [
-            'foo' => 0,
-            'search' => 'b',
-            'page' => 1
-        ]);
-        $this->assertEquals(2, $query->clause('where')->count());
-
-        $query = $this->Articles->find('search', [
-            '_search' => [
-                'foo' => 'a',
-                'search' => 'b',
-                'group' => 'main'
-            ]
-        ]);
-        $this->assertEquals(3, $query->clause('where')->count());
+        $query = $this->Articles->find('search');
     }
 
     /**
@@ -112,7 +102,7 @@ class SearchBehaviorTest extends TestCase
     public function testFilterParams()
     {
         $result = $this->Articles->filterParams(['foo' => 'bar']);
-        $this->assertEquals(['_search' => ['foo' => 'bar']], $result);
+        $this->assertEquals(['search' => ['foo' => 'bar']], $result);
     }
 
     /**


### PR DESCRIPTION
I don't think it's prudent to allow usage like `find('search', $this->request->url)`. Passing querysting directly as find options is pretty risky thing imo. Keys could easily clash with core options or other custom options of custom finders. A user can for e.g. just tack on `&group=foo` and mess up your query. This patch will force people to always use `find('search', ['search' => $this->request->url])`.

I have also rename key "_search" back to "search" to maintain BC. Don't much value in adding the prefix and making people update their code.