### PR TITLE
Auto alias fields in filters.

### DIFF
--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -58,6 +58,7 @@ abstract class Base
 
         $defaults = [
             'field' => $name,
+            'aliasField' => true,
             'name' => $name,
             'validate' => [],
             'alwaysRun' => false,
@@ -85,7 +86,25 @@ abstract class Base
      */
     public function field()
     {
-        return $this->config('field');
+        $field = $this->config('field');
+        if (!$this->config('aliasField')) {
+            return $field;
+        }
+
+        $repository = $this->manager()->repository();
+        if (!method_exists($repository, 'aliasField')) {
+            return $field;
+        }
+
+        if (is_string($field)) {
+            return $repository->aliasField($field);
+        }
+
+        $return = [];
+        foreach ($field as $fld) {
+            $return[] = $repository->aliasField($fld);
+        }
+        return $return;
     }
 
     /**

--- a/tests/TestCase/Model/Filter/BaseTest.php
+++ b/tests/TestCase/Model/Filter/BaseTest.php
@@ -2,6 +2,7 @@
 namespace Search\Test\TestCase\Model\Filter;
 
 use Cake\TestSuite\TestCase;
+use Cake\ORM\TableRegistry;
 use Search\Manager;
 use Search\Model\Filter\Base;
 
@@ -16,12 +17,22 @@ class Filter extends Base
 class BaseTest extends TestCase
 {
 
+    public $fixtures = [
+        'plugin.Search.Articles'
+    ];
+
+    public function setup()
+    {
+        $table = TableRegistry::get('Articles');
+        $manager = new Manager($table);
+        $this->manager = new Manager($table);
+    }
+
     public function testSkip()
     {
-        $manager = $this->getMock('\Search\Manager', null, [], 'Manager', false);
         $filter = new Filter(
             'field',
-            $manager,
+            $this->manager,
             ['alwaysRun' => true, 'filterEmpty' => true]
         );
 
@@ -36,5 +47,28 @@ class BaseTest extends TestCase
 
         $filter->args(['field' => []]);
         $this->assertTrue($filter->skip());
+    }
+
+    public function testFieldAliasing()
+    {
+        $filter = new Filter(
+            'field',
+            $this->manager,
+            []
+        );
+
+        $this->assertEquals('Articles.field', $filter->field());
+
+        $filter->config('aliasField', false);
+        $this->assertEquals('field', $filter->field());
+
+        $filter = new Filter(
+            ['field1', 'field2'],
+            $this->manager,
+            []
+        );
+
+        $expected = ['Articles.field1', 'Articles.field2'];
+        $this->assertEquals($expected, $filter->field());
     }
 }

--- a/tests/TestCase/Model/Filter/BaseTest.php
+++ b/tests/TestCase/Model/Filter/BaseTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace Search\Test\TestCase\Model\Filter;
 
-use Cake\TestSuite\TestCase;
 use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
 use Search\Manager;
 use Search\Model\Filter\Base;
 


### PR DESCRIPTION
This saves users using Table::aliasField() each time when configuring filters
to avoid "ambiguous column" sql errors.

I'll add / update tests if people like the idea.