### PR TITLE
Resolves #104

### DIFF
--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -114,7 +114,7 @@ abstract class Base
      */
     public function fields()
     {
-        return (array)$this->config('field');
+        return (array)$this->field();
     }
 
     /**

--- a/tests/TestCase/Model/Filter/LikeTest.php
+++ b/tests/TestCase/Model/Filter/LikeTest.php
@@ -36,14 +36,14 @@ class LikeTest extends TestCase
         $filter->process();
 
         $sql = $filter->query()->sql();
-        $this->assertEquals(1, preg_match('/WHERE title like/', $sql));
+        $this->assertEquals(1, preg_match('/WHERE Articles.title like/', $sql));
 
         $filter->config('comparison', 'ILIKE');
         $filter->query($articles->find());
         $filter->process();
 
         $sql = $filter->query()->sql();
-        $this->assertEquals(1, preg_match('/WHERE title ilike/', $sql));
+        $this->assertEquals(1, preg_match('/WHERE Articles.title ilike/', $sql));
     }
 
     /**


### PR DESCRIPTION
Instead of reading the field from the configuration use the method, so that the `aliasFields` setting is respected.

Updated the matching test as well.