### PR TITLE
Documentation, filter names are ucfirst()

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,13 +193,13 @@ populated from the query params.
 The Search plugin comes with a set of predefined search filters that allow you to
 easily create the search results you need. Use:
 
-- ``value`` to limit results to exact matches
-- ``like`` to produce results containing the search query (``LIKE`` or ``ILIKE``)
-- ``boolean`` to limit results by truthy (by default: 1, true, '1', 'true', 'yes', 'on') and falsy (by default: 0, false, '0', 'false', 'no', 'off') values which are passed down to the ORM as true/1 or false/0 or ignored when being neither truthy or falsy.
-- ``finder`` to produce results using a [(custom)](http://book.cakephp.org/3.0/en/orm/retrieving-data-and-resultsets.html#custom-find-methods) finder
-- ``compare`` to produce results requiring operator comparison (
+- ``Value`` to limit results to exact matches
+- ``Like`` to produce results containing the search query (``LIKE`` or ``ILIKE``)
+- ``Boolean`` to limit results by truthy (by default: 1, true, '1', 'true', 'yes', 'on') and falsy (by default: 0, false, '0', 'false', 'no', 'off') values which are passed down to the ORM as true/1 or false/0 or ignored when being neither truthy or falsy.
+- ``Finder`` to produce results using a [(custom)](http://book.cakephp.org/3.0/en/orm/retrieving-data-and-resultsets.html#custom-find-methods) finder
+- ``Compare`` to produce results requiring operator comparison (
     ``>``, ``<``, ``>=`` and ``<=``)
-- ``callback`` to produce results using your own custom callable function
+- ``Callback`` to produce results using your own custom callable function
 
 ## Optional fields
 


### PR DESCRIPTION
The names of the filters are always spelled with first character uppercase. 
See https://github.com/FriendsOfCake/search/issues/115#issuecomment-244936130