### PR TITLE
Add multi-value search support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ well. In your table classes `initialize()` method call the `searchManager()`
 method, it will return a search manager instance. You can now add filters to the
 manager by chaining them. The first arg of the `add()` method is the field, the
 second the filter using the dot notation of cake to load filters from plugins.
-The third one is an array of filter specific options.
+The third one is an array of filter specific options. Please refer to
+[the Options section](#options) for an explanation of the available options
+supported by the different filters.
 
 ```php
 use Search\Manager;
@@ -215,6 +217,95 @@ easily create the search results you need. Use:
 - ``Compare`` to produce results requiring operator comparison (
     ``>``, ``<``, ``>=`` and ``<=``)
 - ``Callback`` to produce results using your own custom callable function
+
+### Options
+
+#### All filters
+
+The following options are supported by all filters.
+
+- `field` (`string`, defaults to the name passed to the first argument of the
+  add filter method) The name of the field to use for searching. Use this option
+  if you need to use a name in your forms that doesn't match the actual field name.
+
+- `name` (`string`, defaults to the name passed to the first argument of the add
+  filter method) The name of the field to look up in the request data. Use this
+  option if you need to configure the name of the filter differently than the name
+  of the field, in cases where you can't use the `field` option, for example when it
+  is being used to define multiple fields, which is supported by the `Like` filter.
+
+- `alwaysRun` (`bool`, defaults to `false`) Defines whether the filter should always
+  run, irrespectively of whether the corresponding field exists in the request data.
+
+- `filterEmpty` (`bool`, defaults to `false`) Defines whether the filter should not
+  run in case the corresponding field in the request is empty. Refer to
+  [the Optional fields section](#optional-fields) for additional details.
+
+The following options are supported by all filters except `Callback` and `Finder`.
+
+- `aliasField` (`bool`, defaults to `true`) Defines whether the field name should
+  be aliased with respect to the alias used by the table class to which the behavior
+  is attached to.
+
+- `defaultValue` (`mixed`, defaults to `null`) The default value that is being
+  used in case the value passed for the corresponding field is invalid or missing.
+
+#### `Compare`
+
+- `operator` (`string`, defaults to `>=`) The operator to use for comparison. Valid
+  values are `>=`, `<=`, `>` and `<`.
+
+#### `Like`
+
+- `multiValue` (`bool`, defaults to `false`) Defines whether the filter accepts
+  multiple values. If disabled, and multiple values are being passed, the filter
+  will fall back to using the default value defined by the `defaultValue` option.
+
+- `field` (`string|array`, defaults to ) The name of the field to use for
+  searching. Works like the base `field` option but also accepts multiple field
+  names as an array. When defining multiple fields, the search term is going to
+  be looked up in all the given fields, using the conditional operator defined by
+  the `fieldMode` option. 
+
+- `before` (`bool`, defaults to `false`) Whether to automatically add a wildcard
+  *before* the search term.
+
+- `after` (`bool`, defaults to `false`) Whether to automatically add a wildcard
+  *after* the search term.
+
+- `mode` (`string`, default to `or`) **This options is deprecated**, please use
+  `fieldMode` instead.
+
+- `fieldMode` (`string`, defaults to `or`) The conditional mode to use when
+  matching against multiple fields.
+
+- `valueMode` (`string`, defaults to `or`) The conditional mode to use when
+  searching for multiple values.
+
+- `comparison` (`string`, defaults to `LIKE`) The comparison operator to use.
+
+- `wildcardAny` (`string`, defaults to `*`) Defines the string that should be
+  treated as a _any_ wildcard in case it is being encountered in the search term.
+  The behavior will internally replace this with the appropriate `LIKE`
+  compatible wildcard. This is useful if you want to pass wildcards inside of the
+  search term, while still being able to use the actual wildcard character inside
+  of the search term so that it is being treated as a part of the term. For example
+  a search term of `* has reached 100%` would be converted to `% has reached 100\%`.
+
+- `wildcardOne` (`string`, defaults to `?`) Defines the string that should be
+  treated as a _one_ wildcard in case it is being encountered in the search term.
+  Behaves similar to `wildcardAny`, that is, the actual `LIKE` compatible wildcard
+  (`_`) is being escaped in case used the search term.
+
+#### `Value`
+
+- `multiValue` (`bool`, defaults to `false`) Defines whether the filter accepts
+  multiple values. If disabled, and multiple values are being passed, the filter
+  will fall back to using the default value defined by the `defaultValue` option.
+
+- `mode` (`string`, possible values are `or` and `and`, defaults to `or`) The
+  conditional mode to use when searching for multiple values.
+
 
 ## Optional fields
 

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -63,7 +63,8 @@ abstract class Base
             'validate' => [],
             'alwaysRun' => false,
             'filterEmpty' => false,
-            'defaultValue' => null
+            'defaultValue' => null,
+            'multiValue' => false,
         ];
 
         $this->config($config + $defaults);
@@ -169,7 +170,17 @@ abstract class Base
      */
     public function value()
     {
-        return isset($this->_args[$this->name()]) ? $this->_args[$this->name()] : $this->_config['defaultValue'];
+        $value = $this->_config['defaultValue'];
+        if (isset($this->_args[$this->name()])) {
+            $passedValue = $this->_args[$this->name()];
+            if (!is_array($passedValue) ||
+                $this->config('multiValue')
+            ) {
+                return $passedValue;
+            }
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -1,6 +1,8 @@
 <?php
 namespace Search\Model\Filter;
 
+use Search\Manager;
+
 class Like extends Base
 {
 
@@ -12,11 +14,34 @@ class Like extends Base
     protected $_defaultConfig = [
         'before' => false,
         'after' => false,
-        'mode' => 'or',
+        'mode' => null,
+        'fieldMode' => 'or',
+        'valueMode' => 'or',
         'comparison' => 'LIKE',
         'wildcardAny' => '*',
         'wildcardOne' => '?',
     ];
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param string $name Name.
+     * @param \Search\Manager $manager Manager.
+     * @param array $config Config.
+     */
+    public function __construct($name, Manager $manager, array $config = [])
+    {
+        parent::__construct($name, $manager, $config);
+
+        $mode = $this->config('mode');
+        if ($mode !== null) {
+            trigger_error(
+                'The `mode` configuration option is deprecated, use `fieldMode` and `valueMode` instead.',
+                E_USER_DEPRECATED
+            );
+            $this->config('fieldMode', $mode);
+        }
+    }
 
     /**
      * Process a LIKE condition ($x LIKE $y).
@@ -29,31 +54,49 @@ class Like extends Base
             return;
         }
 
+        $comparison = $this->config('comparison');
+        $valueMode = $this->config('valueMode');
+        $value = $this->value();
+        $isMultiValue = is_array($value);
+
         $conditions = [];
         foreach ($this->fields() as $field) {
-            $left = $field . ' ' . $this->config('comparison');
-            $right = $this->_wildcards($this->value());
-
-            $conditions[] = [$left => $right];
+            $left = $field . ' ' . $comparison;
+            if ($isMultiValue) {
+                $valueConditions = [];
+                foreach ($value as $val) {
+                    $right = $this->_wildcards($val);
+                    if ($right !== false) {
+                        $valueConditions[] = [$left => $right];
+                    }
+                }
+                if (!empty($valueConditions)) {
+                    $conditions[] = [$valueMode => $valueConditions];
+                }
+            } else {
+                $right = $this->_wildcards($value);
+                if ($right !== false) {
+                    $conditions[] = [$left => $right];
+                }
+            }
         }
 
-        $this->query()->andWhere([$this->config('mode') => $conditions]);
+        if (!empty($conditions)) {
+            $this->query()->andWhere([$this->config('fieldMode') => $conditions]);
+        }
     }
 
     /**
      * Wrap wild cards around the value.
      *
-     * @param  string $value Value.
-     * @return string
+     * @param string $value Value.
+     * @return string|false Either the wildcard decorated input value, or `false` when
+     *  encountering a non-string value.
      */
     protected function _wildcards($value)
     {
-        if (is_array($value)) {
-            foreach ($value as $k => $v) {
-                $value[$k] = $this->_wildcards($v);
-            }
-
-            return $value;
+        if (!is_string($value)) {
+            return false;
         }
 
         $value = $this->_formatWildcards($value);

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -35,10 +35,6 @@ class Like extends Base
 
         $mode = $this->config('mode');
         if ($mode !== null) {
-            trigger_error(
-                'The `mode` configuration option is deprecated, use `fieldMode` and `valueMode` instead.',
-                E_USER_DEPRECATED
-            );
             $this->config('fieldMode', $mode);
         }
     }

--- a/src/Model/Filter/Value.php
+++ b/src/Model/Filter/Value.php
@@ -5,6 +5,15 @@ class Value extends Base
 {
 
     /**
+     * Default configuration.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'mode' => 'or',
+    ];
+
+    /**
      * Process a value condition ($x == $y).
      *
      * @return void
@@ -16,7 +25,25 @@ class Value extends Base
         }
 
         $this->query()->andWhere(function ($e) {
-            return $e->in($this->field(), $this->value());
+            /* @var $e \Cake\Database\Expression\QueryExpression */
+            $value = $this->value();
+            if ($value === null) {
+                return $e;
+            }
+
+            $field = $this->field();
+
+            if (strtolower($this->config('mode')) === 'or' &&
+                is_array($value)
+            ) {
+                return $e->in($field, $value);
+            }
+
+            foreach ((array)$value as $val) {
+                $e->eq($field, $val);
+            }
+
+            return $e;
         });
     }
 }

--- a/tests/TestCase/Model/Filter/BaseTest.php
+++ b/tests/TestCase/Model/Filter/BaseTest.php
@@ -49,6 +49,31 @@ class BaseTest extends TestCase
         $this->assertTrue($filter->skip());
     }
 
+    /**
+     * @return void
+     */
+    public function testValue()
+    {
+        $filter = new Filter(
+            'field',
+            $this->manager,
+            ['defaultValue' => 'default']
+        );
+
+        $filter->args(['field' => 'value']);
+        $this->assertEquals('value', $filter->value());
+
+        $filter->args(['other_field' => 'value']);
+        $this->assertEquals('default', $filter->value());
+
+        $filter->args(['field' => ['value1', 'value2']]);
+        $this->assertEquals('default', $filter->value());
+
+        $filter->config('multiValue', true);
+        $filter->args(['field' => ['value1', 'value2']]);
+        $this->assertEquals(['value1', 'value2'], $filter->value());
+    }
+
     public function testFieldAliasing()
     {
         $filter = new Filter(

--- a/tests/TestCase/Model/Filter/LikeTest.php
+++ b/tests/TestCase/Model/Filter/LikeTest.php
@@ -1,13 +1,10 @@
 <?php
 namespace Search\Test\TestCase\Model\Filter;
 
-use Cake\Core\Configure;
-use Cake\ORM\Entity;
-use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 use Search\Manager;
-use Search\Model\Filter\Base;
 use Search\Model\Filter\Like;
 
 class LikeTest extends TestCase
@@ -25,6 +22,31 @@ class LikeTest extends TestCase
     /**
      * @return void
      */
+    public function testDeprecatedModeOption()
+    {
+        $message = null;
+        $oldHandler = set_error_handler(function ($errno, $errstr) use (&$oldHandler, &$message) {
+            if ($errno === E_USER_DEPRECATED) {
+                $message = $errstr;
+            } else {
+                call_user_func_array($oldHandler, func_get_args());
+            }
+        });
+
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+
+        $filter = new Like('title', $manager, ['mode' => 'modeValue']);
+
+        restore_error_handler();
+
+        $this->assertEquals(
+            'The `mode` configuration option is deprecated, use `fieldMode` and `valueMode` instead.',
+            $message
+        );
+        $this->assertEquals('modeValue', $filter->config('fieldMode'));
+    }
+
     public function testProcess()
     {
         $articles = TableRegistry::get('Articles');
@@ -35,15 +57,231 @@ class LikeTest extends TestCase
         $filter->query($articles->find());
         $filter->process();
 
-        $sql = $filter->query()->sql();
-        $this->assertEquals(1, preg_match('/WHERE Articles.title like/', $sql));
+        $this->assertRegExp(
+            '/WHERE Articles\.title like \:c0$/',
+            $filter->query()->sql()
+        );
+        $this->assertEquals(
+            ['test'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
 
         $filter->config('comparison', 'ILIKE');
         $filter->query($articles->find());
         $filter->process();
 
-        $sql = $filter->query()->sql();
-        $this->assertEquals(1, preg_match('/WHERE Articles.title ilike/', $sql));
+        $this->assertRegExp(
+            '/WHERE Articles\.title ilike \:c0$/',
+            $filter->query()->sql()
+        );
+        $this->assertEquals(
+            ['test'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessSingleValueWithAndValueMode()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Like('title', $manager, ['valueMode' => 'and']);
+        $filter->args(['title' => 'foo']);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertRegExp(
+            '/WHERE Articles\.title like :c0$/',
+            $filter->query()->sql()
+        );
+        $this->assertEquals(
+            ['foo'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessSingleValueAndMultiFieldWithAndValueMode()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Like('title', $manager, [
+            'field' => ['title', 'other'],
+            'valueMode' => 'and'
+        ]);
+        $filter->args(['title' => 'foo']);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertRegExp(
+            '/WHERE \(Articles\.title like :c0 OR Articles\.other like :c1\)$/',
+            $filter->query()->sql()
+        );
+        $this->assertEquals(
+            ['foo', 'foo'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessMultiValue()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Like('title', $manager, ['multiValue' => true]);
+        $filter->args(['title' => ['foo', 'bar']]);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertRegExp(
+            '/WHERE \(Articles\.title like :c0 OR Articles\.title like :c1\)$/',
+            $filter->query()->sql()
+        );
+        $this->assertEquals(
+            ['foo', 'bar'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessMultiValueWithAndValueMode()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Like('title', $manager, [
+            'multiValue' => true,
+            'valueMode' => 'and'
+        ]);
+        $filter->args(['title' => ['foo', 'bar']]);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertRegExp(
+            '/WHERE \(Articles\.title like :c0 AND Articles\.title like :c1\)$/',
+            $filter->query()->sql()
+        );
+        $this->assertEquals(
+            ['foo', 'bar'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessMultiValueAndMultiField()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Like('title', $manager, [
+            'multiValue' => true,
+            'field' => ['title', 'other']
+        ]);
+        $filter->args(['title' => ['foo', 'bar']]);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertRegExp(
+            '/WHERE \(\(Articles\.title like :c0 OR Articles\.title like :c1\) ' .
+                'OR \(Articles\.other like :c2 OR Articles\.other like :c3\)\)$/',
+            $filter->query()->sql()
+        );
+        $this->assertEquals(
+            ['foo', 'bar', 'foo', 'bar'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessMultiValueAndMultiFieldWithAndFieldMode()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Like('title', $manager, [
+            'multiValue' => true,
+            'field' => ['title', 'other'],
+            'fieldMode' => 'and'
+        ]);
+        $filter->args(['title' => ['foo', 'bar']]);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertRegExp(
+            '/WHERE \(\(Articles\.title like :c0 OR Articles\.title like :c1\) ' .
+                'AND \(Articles\.other like :c2 OR Articles\.other like :c3\)\)$/',
+            $filter->query()->sql()
+        );
+        $this->assertEquals(
+            ['foo', 'bar', 'foo', 'bar'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessMultiValueWithNonScalarValue()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Like('title', $manager, ['multiValue' => true]);
+        $filter->args(['title' => ['foo' => ['bar']]]);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertEmpty($filter->query()->clause('where'));
+        $this->assertEmpty(Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessDefaultFallbackForDisallowedMultiValue()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Like('title', $manager, ['defaultValue' => 'default']);
+        $filter->args(['title' => ['foo', 'bar']]);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertRegExp(
+            '/WHERE Articles\.title like :c0$/',
+            $filter->query()->sql()
+        );
+        $this->assertEquals(
+            ['default'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessNoDefaultFallbackForDisallowedMultiValue()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Like('title', $manager);
+        $filter->args(['title' => ['foo', 'bar']]);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertNotRegExp(
+            '/Articles\.title like/',
+            $filter->query()->sql()
+        );
+        $this->assertEmpty($filter->query()->valueBinder()->bindings());
     }
 
     /**
@@ -60,9 +298,10 @@ class LikeTest extends TestCase
         $filter->process();
 
         $filter->query()->sql();
-        $values = $filter->query()->valueBinder()->bindings();
-        $value = $values[':c0']['value'];
-        $this->assertEquals('part\_1 _ 100\% %', $value);
+        $this->assertEquals(
+            ['part\_1 _ 100\% %'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
     }
 
     /**
@@ -79,28 +318,10 @@ class LikeTest extends TestCase
         $filter->process();
 
         $filter->query()->sql();
-        $values = $filter->query()->valueBinder()->bindings();
-        $value = $values[':c0']['value'];
-        $this->assertEquals('%22\% 44\_%', $value);
-    }
-
-    /**
-     * @return void
-     */
-    public function testWildcardsArray()
-    {
-        $articles = TableRegistry::get('Articles');
-        $manager = new Manager($articles);
-
-        $filter = new Like('title', $manager, ['before' => true, 'after' => true]);
-        $filter->args(['title' => ['22% 44_']]);
-        $filter->query($articles->find());
-        $filter->process();
-
-        $filter->query()->sql();
-        $values = $filter->query()->valueBinder()->bindings();
-        $value = $values[':c0']['value'][0];
-        $this->assertEquals('%22\% 44\_%', $value);
+        $this->assertEquals(
+            ['%22\% 44\_%'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
     }
 
     /**
@@ -121,8 +342,9 @@ class LikeTest extends TestCase
         $filter->process();
 
         $filter->query()->sql();
-        $values = $filter->query()->valueBinder()->bindings();
-        $value = $values[':c0']['value'];
-        $this->assertEquals('%22% 44_%', $value);
+        $this->assertEquals(
+            ['%22% 44_%'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
     }
 }

--- a/tests/TestCase/Model/Filter/LikeTest.php
+++ b/tests/TestCase/Model/Filter/LikeTest.php
@@ -24,27 +24,13 @@ class LikeTest extends TestCase
      */
     public function testDeprecatedModeOption()
     {
-        $message = null;
-        $oldHandler = set_error_handler(function ($errno, $errstr) use (&$oldHandler, &$message) {
-            if ($errno === E_USER_DEPRECATED) {
-                $message = $errstr;
-            } else {
-                call_user_func_array($oldHandler, func_get_args());
-            }
-        });
-
         $articles = TableRegistry::get('Articles');
         $manager = new Manager($articles);
-
         $filter = new Like('title', $manager, ['mode' => 'modeValue']);
 
-        restore_error_handler();
-
-        $this->assertEquals(
-            'The `mode` configuration option is deprecated, use `fieldMode` and `valueMode` instead.',
-            $message
-        );
+        $this->assertEquals('modeValue', $filter->config('mode'));
         $this->assertEquals('modeValue', $filter->config('fieldMode'));
+        $this->assertEquals('or', $filter->config('valueMode'));
     }
 
     public function testProcess()

--- a/tests/TestCase/Model/Filter/ValueTest.php
+++ b/tests/TestCase/Model/Filter/ValueTest.php
@@ -1,13 +1,10 @@
 <?php
 namespace Search\Test\TestCase\Model\Filter;
 
-use Cake\Core\Configure;
-use Cake\ORM\Entity;
-use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 use Search\Manager;
-use Search\Model\Filter\Base;
 use Search\Model\Filter\Value;
 
 class ValueTest extends TestCase
@@ -26,9 +23,175 @@ class ValueTest extends TestCase
     {
         $articles = TableRegistry::get('Articles');
         $manager = new Manager($articles);
-        $value = new Value('title', $manager);
-        $value->args(['title' => ['test']]);
-        $value->query($articles->find());
-        $result = $value->process();
+        $filter = new Value('title', $manager);
+        $filter->args(['title' => 'test']);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertRegExp(
+            '/WHERE Articles\.title = :c0$/',
+            $filter->query()->sql()
+        );
+        $this->assertEquals(
+            ['test'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessSingleValueWithAndMode()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Value('title', $manager, ['mode' => 'and']);
+        $filter->args(['title' => 'foo']);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertRegExp(
+            '/WHERE Articles\.title = :c0$/',
+            $filter->query()->sql()
+        );
+        $this->assertEquals(
+            ['foo'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessMultiValue()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Value('title', $manager, ['multiValue' => true]);
+        $filter->args(['title' => ['foo', 'bar']]);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertRegExp(
+            '/WHERE Articles\.title IN \(:c0,:c1\)$/',
+            $filter->query()->sql()
+        );
+        $this->assertEquals(
+            ['foo', 'bar'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessMultiValueWithAndMode()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Value('title', $manager, [
+            'multiValue' => true,
+            'mode' => 'and'
+        ]);
+        $filter->args(['title' => ['foo', 'bar']]);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertRegExp(
+            '/WHERE \(Articles\.title = :c0 AND Articles\.title = :c1\)$/',
+            $filter->query()->sql()
+        );
+        $this->assertEquals(
+            ['foo', 'bar'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessMultiValueWithNonScalarValue()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Value('title', $manager, ['multiValue' => true]);
+        $filter->args(['title' => ['foo' => ['bar']]]);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertRegExp(
+            '/WHERE Articles\.title IN \(:c0\)$/',
+            $filter->query()->sql()
+        );
+        $this->assertEquals(
+            [['bar']],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessDefaultFallbackForDisallowedMultiValue()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Value('title', $manager, ['defaultValue' => 'default']);
+        $filter->args(['title' => ['foo', 'bar']]);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertRegExp(
+            '/WHERE Articles\.title = :c0$/',
+            $filter->query()->sql()
+        );
+        $this->assertEquals(
+            ['default'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessNoDefaultFallbackForDisallowedMultiValue()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Value('title', $manager);
+        $filter->args(['title' => ['foo', 'bar']]);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertNotRegExp(
+            '/Articles\.title like/',
+            $filter->query()->sql()
+        );
+        $this->assertEmpty($filter->query()->valueBinder()->bindings());
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessCaseInsensitiveMode()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Value('title', $manager, [
+            'multiValue' => true,
+            'mode' => 'Or'
+        ]);
+        $filter->args(['title' => ['foo', 'bar']]);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $this->assertRegExp(
+            '/WHERE Articles\.title IN \(:c0,:c1\)$/',
+            $filter->query()->sql()
+        );
+        $this->assertEquals(
+            ['foo', 'bar'],
+            Hash::extract($filter->query()->valueBinder()->bindings(), '{s}.value')
+        );
     }
 }


### PR DESCRIPTION
This is a first attempt of implementing #77

This change introduces the `modeValue` option in the `Base` filter. Support for it is being implemented in the `Value` and `Like` filters, it doesn't seem to make sense for any other filter, `Boolean` is binary, and for `Comparison` only one value only ever really would have an effect.

The `Base` filter exposes multiple values only in case the `multiValue` option is enabled, otherwise it will fall back to returning the default value, basically treating the arguments as non-existing.

For the `Value` filter, in `or` mode, `IN()` is kept being used, IIRC this is less parser/optimizer heavy than multiple `OR`s. For the `and` mode multiple `AND`s are being used, as for using `IN()` this would require grouping and using `HAVING`, and I'm not sure that such modifications are overly welcome.

The `Like` filter simply builds multiple (nested) `AND`/`OR`s.

Docs will be added once this is considered good to merge.

---

There a few things that not everyone may be sold on, like

* Deprecating the `mode` option (and triggering a notice :fearful:) for the `Like` filter, and introducing two separate options, `fieldMode` and `valueMode`, where the former is used for the possible multiple fields, and the latter for the possible multiple values.

  There are for sure other ways to handle this, like for example
  
  * Instead of deprecating, use the `mode` value as the default for `fieldMode` and `valueMode` in case they haven't explicitly been configured.
  
  * Again use `mode` as the default, but make it also accept an array with further separate keys to configure the mode for the fields and the values separately.

  * ...

* Testing the `findSearch` method in such an explicit manner.

* They way how the "_no default value_" situation is being handled, see the `testProcessNoDefaultFallbackForDisallowedMultiValue` tests.