### PR TITLE
Allow numeric fields to be LIKE searched without auto-cast bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,11 +264,15 @@ The following options are supported by all filters except `Callback` and `Finder
   multiple values. If disabled, and multiple values are being passed, the filter
   will fall back to using the default value defined by the `defaultValue` option.
 
-- `field` (`string|array`, defaults to the name passed to the first argument of the
+- `field` (`string|array`), defaults to the name passed to the first argument of the
   add filter method) The name of the field to use for searching. Works like the base
   `field` option but also accepts multiple field names as an array. When defining
   multiple fields, the search term is going to be looked up in all the given fields,
   using the conditional operator defined by the `fieldMode` option.
+  
+- `colType` (`array|bool`), defaults to auto-detecting any column that needs to be treated as
+  string column despite its actual type. You can also manually define the types for those fields.
+  Set to `false` to completely remove the detection.
 
 - `before` (`bool`, defaults to `false`) Whether to automatically add a wildcard
   *before* the search term.

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -20,6 +20,7 @@ class Like extends Base
         'comparison' => 'LIKE',
         'wildcardAny' => '*',
         'wildcardOne' => '?',
+        'colType' => [],
     ];
 
     /**
@@ -56,10 +57,11 @@ class Like extends Base
         $isMultiValue = is_array($value);
 
         $conditions = [];
-        $types = [];
+        $colTypes = $this->config('colType') ?: [];
+        $detectColTypesFromSchema = ($colTypes || $this->config('colType') === false) ? false : true;
         foreach ($this->fields() as $field) {
-            if ($this->_requiresTypeMapping($field)) {
-                $types[$field] = 'string';
+            if ($detectColTypesFromSchema && $this->_requiresTypeMapping($field)) {
+                $colTypes[$field] = 'string';
             }
 
             $left = $field . ' ' . $comparison;
@@ -83,7 +85,7 @@ class Like extends Base
         }
 
         if (!empty($conditions)) {
-            $this->query()->andWhere([$this->config('fieldMode') => $conditions], $types);
+            $this->query()->andWhere([$this->config('fieldMode') => $conditions], $colTypes);
         }
     }
 

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -90,8 +90,7 @@ class Like extends Base
     }
 
     /**
-     * @param string $field
-     *
+     * @param string $field Field
      * @return bool
      */
     protected function _requiresTypeMapping($field)

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -14,6 +14,7 @@ class ArticlesFixture extends TestFixture
     public $fields = [
         'id' => ['type' => 'string', 'null' => false, 'length' => 36],
         'title' => ['type' => 'string', 'null' => false, 'default' => null],
+        'number' => ['type' => 'integer', 'null' => true, 'default' => null],
         'is_active' => ['type' => 'boolean', 'null' => false, 'default' => true],
         'created' => ['type' => 'datetime', 'null' => true, 'default' => null],
         'modified' => ['type' => 'datetime', 'null' => true, 'default' => null],
@@ -28,6 +29,7 @@ class ArticlesFixture extends TestFixture
         [
             'id' => '1',
             'title' => 'Test title one',
+            'number' => '123456',
             'is_active' => true,
             'created' => '2012-12-12 12:12:12',
             'modified' => '2013-01-01 11:11:11',

--- a/tests/TestCase/Model/Filter/LikeTest.php
+++ b/tests/TestCase/Model/Filter/LikeTest.php
@@ -260,6 +260,35 @@ class LikeTest extends TestCase
     /**
      * @return void
      */
+    public function testProcessWithNumericFields()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Like('search', $manager, ['field' => ['title', 'number']]);
+        $filter->args(['search' => '234']);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $filter->query()->sql();
+        $bindings = $filter->query()->valueBinder()->bindings();
+        $expected = [
+            ':c0' => [
+                'value' => '234',
+                'type' => 'string',
+                'placeholder' => 'c0'
+            ],
+            ':c1' => [
+                'value' => '234',
+                'type' => 'string',
+                'placeholder' => 'c1'
+            ],
+        ];
+        $this->assertSame($expected, $bindings);
+    }
+
+    /**
+     * @return void
+     */
     public function testProcessEmptyMultiValue()
     {
         $articles = TableRegistry::get('Articles');

--- a/tests/TestCase/Model/Filter/LikeTest.php
+++ b/tests/TestCase/Model/Filter/LikeTest.php
@@ -289,6 +289,35 @@ class LikeTest extends TestCase
     /**
      * @return void
      */
+    public function testProcessWithNumericFieldsDisableAutoColType()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Like('search', $manager, ['field' => ['title', 'number'], 'colType' => false]);
+        $filter->args(['search' => '234']);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $filter->query()->sql();
+        $bindings = $filter->query()->valueBinder()->bindings();
+        $expected = [
+            ':c0' => [
+                'value' => '234',
+                'type' => 'string',
+                'placeholder' => 'c0'
+            ],
+            ':c1' => [
+                'value' => '234',
+                'type' => 'integer',
+                'placeholder' => 'c1'
+            ],
+        ];
+        $this->assertSame($expected, $bindings);
+    }
+
+    /**
+     * @return void
+     */
     public function testProcessEmptyMultiValue()
     {
         $articles = TableRegistry::get('Articles');


### PR DESCRIPTION
Resolves the issue of silent auto-casting (and false positives) when doing string based LIKE searches.

Fixes https://github.com/FriendsOfCake/search/issues/131


Before with `->like('search', ['field' => ['name', 'iso2', 'iso3', 'country_code']]);`:
```sql
WHERE 
  (
    `Countries`.`name` like '123' 
    OR `Countries`.`iso2` like '123' 
    OR `Countries`.`iso3` like '123' 
    OR `Countries`.`country_code` = 0
  ) 
```
After:
```sql
WHERE 
  (
    `Countries`.`name` like '123' 
    OR `Countries`.`iso2` like '123' 
    OR `Countries`.`iso3` like '123' 
    OR `Countries`.`country_code` like '123'
  ) 
```