### PR TITLE
Manual version: Allow numeric fields to be LIKE searched

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ The following options are supported by all filters except `Callback` and `Finder
   using the conditional operator defined by the `fieldMode` option.
   
 - `colType` (`array`), Use to set a custom type for any column that needs to be treated as
-  string column despite its actual type.
+  string column despite its actual type. This is important for integer fields, for example, if they
+  are part of the fields to be searched.
 
 - `before` (`bool`, defaults to `false`) Whether to automatically add a wildcard
   *before* the search term.

--- a/README.md
+++ b/README.md
@@ -264,11 +264,14 @@ The following options are supported by all filters except `Callback` and `Finder
   multiple values. If disabled, and multiple values are being passed, the filter
   will fall back to using the default value defined by the `defaultValue` option.
 
-- `field` (`string|array`, defaults to the name passed to the first argument of the
+- `field` (`string|array`), defaults to the name passed to the first argument of the
   add filter method) The name of the field to use for searching. Works like the base
   `field` option but also accepts multiple field names as an array. When defining
   multiple fields, the search term is going to be looked up in all the given fields,
   using the conditional operator defined by the `fieldMode` option.
+  
+- `colType` (`array`), Use to set a custom type for any column that needs to be treated as
+  string column despite its actual type.
 
 - `before` (`bool`, defaults to `false`) Whether to automatically add a wildcard
   *before* the search term.

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -89,7 +89,7 @@ class Like extends Base
     }
 
     /**
-     * @param array $colTypes
+     * @param array $colTypes Column types
      * @return array
      */
     protected function _aliasColTypes($colTypes)

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -57,7 +57,6 @@ class Like extends Base
         $isMultiValue = is_array($value);
 
         $conditions = [];
-        $colTypes = $this->config('colType') ?: [];
         foreach ($this->fields() as $field) {
             $left = $field . ' ' . $comparison;
             if ($isMultiValue) {
@@ -80,6 +79,7 @@ class Like extends Base
         }
 
         if (!empty($conditions)) {
+            $colTypes = $this->config('colType');
             if ($colTypes) {
                 $colTypes = $this->_aliasColTypes($colTypes);
             }
@@ -89,8 +89,10 @@ class Like extends Base
     }
 
     /**
-     * @param array $colTypes Column types
-     * @return array
+     * Alias the column type fields to match the field aliases of the conditions.
+     *
+     * @param array $colTypes Column types to be aliased.
+     * @return array Aliased column types.
      */
     protected function _aliasColTypes($colTypes)
     {

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -14,6 +14,7 @@ class ArticlesFixture extends TestFixture
     public $fields = [
         'id' => ['type' => 'string', 'null' => false, 'length' => 36],
         'title' => ['type' => 'string', 'null' => false, 'default' => null],
+        'number' => ['type' => 'integer', 'null' => true, 'default' => null],
         'is_active' => ['type' => 'boolean', 'null' => false, 'default' => true],
         'created' => ['type' => 'datetime', 'null' => true, 'default' => null],
         'modified' => ['type' => 'datetime', 'null' => true, 'default' => null],
@@ -28,6 +29,7 @@ class ArticlesFixture extends TestFixture
         [
             'id' => '1',
             'title' => 'Test title one',
+            'number' => '123456',
             'is_active' => true,
             'created' => '2012-12-12 12:12:12',
             'modified' => '2013-01-01 11:11:11',

--- a/tests/TestCase/Model/Filter/LikeTest.php
+++ b/tests/TestCase/Model/Filter/LikeTest.php
@@ -260,6 +260,35 @@ class LikeTest extends TestCase
     /**
      * @return void
      */
+    public function testProcessWithNumericFields()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Like('search', $manager, ['field' => ['title', 'number'], 'colType' => ['number' => 'string']]);
+        $filter->args(['search' => '234']);
+        $filter->query($articles->find());
+        $filter->process();
+
+        $filter->query()->sql();
+        $bindings = $filter->query()->valueBinder()->bindings();
+        $expected = [
+            ':c0' => [
+                'value' => '234',
+                'type' => 'string',
+                'placeholder' => 'c0'
+            ],
+            ':c1' => [
+                'value' => '234',
+                'type' => 'string',
+                'placeholder' => 'c1'
+            ],
+        ];
+        $this->assertSame($expected, $bindings);
+    }
+
+    /**
+     * @return void
+     */
     public function testProcessEmptyMultiValue()
     {
         $articles = TableRegistry::get('Articles');


### PR DESCRIPTION
Alternative to https://github.com/FriendsOfCake/search/pull/150 
I dont like it that this has to be done manually, but so far the autodetecting is not bullet proof and therefore this is probably the safer solution for now.