### PR TITLE
Fix up composer description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "friendsofcake/search",
-    "description": "CakePHP 3.0 easy search framework",
+    "description": "CakePHP Search plugin using PRG pattern",
     "type": "cakephp-plugin",
     "keywords": [
         "cakephp",


### PR DESCRIPTION
Don't use the misleading word framework for a plugin, and also dont use the exact version as this lies now.