### PR TITLE
Allow emptyFields for PRG component in order for isSearch to stay correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,20 @@ Be sure to allow empty in your search form, if you're using one.
 echo $this->Form->input('author_id', ['empty' => 'Pick an author']);
 ```
 
+## Empty fields
+In some cases, e.g. when posting checkboxes, the empty value is not `''` but `'0'`.
+If you want to declare certain values as empty values and prevent the URL of getting the query string attached for this "disabled" search field, you can set `emptyValues` in the component:
+```php
+    $this->loadComponent('Search.Prg', [
+        ...
+        'emptyValues' => [
+            'my_checkbox' => '0',
+        ]
+    ]);
+```
+
+This is needed for the "isSearch" work as expected.
+
 ## Persisting the Query String
 
 Persisting the query string can be done with the `queryStringWhitelist` option.

--- a/src/Controller/Component/PrgComponent.php
+++ b/src/Controller/Component/PrgComponent.php
@@ -18,13 +18,16 @@ class PrgComponent extends Component
      * - `queryStringToData` : Set query string as request data. Default `true`.
      * - `queryStringWhitelist` : An array of whitelisted query strings to be kept.
      *   Defaults to the Paginator `'sort'`, `'direction'` and `'limit'` ones.
+     * - `emptyValues` : A map of fields and their values to be considered empty 
+     *   (will not be passed along in the URL).
      *
      * @var array
      */
     protected $_defaultConfig = [
         'actions' => ['index', 'lookup'],
         'queryStringToData' => true,
-        'queryStringWhitelist' => ['sort', 'direction', 'limit']
+        'queryStringWhitelist' => ['sort', 'direction', 'limit'],
+        'emptyValues' => [],
     ];
 
     /**
@@ -95,6 +98,16 @@ class PrgComponent extends Component
     protected function _filterParams()
     {
         $params = Hash::filter($this->request->data);
+
+        foreach ((array)$this->config('emptyValues') as $field => $value) {
+            if (!isset($params[$field])) {
+                continue;
+            }
+
+            if ($params[$field] === (string)$value) {
+                unset($params[$field]);
+            }
+        }
 
         if (!$this->config('queryStringWhitelist')) {
             return $params;

--- a/tests/TestCase/Controller/Component/PrgComponentTest.php
+++ b/tests/TestCase/Controller/Component/PrgComponentTest.php
@@ -121,6 +121,27 @@ class SearchComponentTest extends TestCase
     /**
      * @return void
      */
+    public function testInitializePostWithEmptyValues()
+    {
+        $this->Controller->request->params = [
+            'controller' => 'Posts',
+            'action' => 'index',
+            'pass' => ['pass']
+        ];
+        $this->Controller->request->here = '/Posts/index/pass';
+        $this->Controller->request->data = ['foo' => 'bar', 'checkbox' => '0'];
+        $this->Controller->request->env('REQUEST_METHOD', 'POST');
+
+        $this->Prg->configShallow('emptyValues', [
+            'checkbox' => '0',
+        ]);
+        $response = $this->Prg->startup();
+        $this->assertEquals('http://localhost/Posts/index/pass?foo=bar', $response->header()['Location']);
+    }
+
+    /**
+     * @return void
+     */
     public function testInitializePostWithQueryStringWhitelist()
     {
         $this->Controller->request->query = [


### PR DESCRIPTION
This came up a few times before as an issue if I recall correctly.

In my case
```php
	echo $this->Form->input('search');
	echo $this->Form->input('has_missing_translation', ['type' => 'checkbox']);
```

The 0 posted will always result in the URL `?has_missing_translation=0`, which then also affects the isSearch and the reset button in the process.
The empty values should be seen as such (as the CakeDC one did). This is a non-invasive minimal BC safe addition that resolves the issue.