### PR TITLE
Add multi-field search support to value filter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,8 +319,8 @@ The following options are supported by all filters except `Callback` and `Finder
   multiple values. If disabled, and multiple values are being passed, the filter
   will fall back to using the default value defined by the `defaultValue` option.
 
-- `mode` (`string`, defaults to `OR`) The conditional mode to use when searching for
-  multiple values. Valid values are `OR` and `AND`.
+- `mode` (`string`, defaults to `OR`) The conditional mode to use when matching
+  against multiple fields. Valid values are `OR` and `AND`.
 
 #### `Finder`
 

--- a/src/Model/Filter/Value.php
+++ b/src/Model/Filter/Value.php
@@ -1,6 +1,9 @@
 <?php
 namespace Search\Model\Filter;
 
+use Cake\Database\Expression\QueryExpression;
+use Search\Manager;
+
 class Value extends Base
 {
 
@@ -10,8 +13,27 @@ class Value extends Base
      * @var array
      */
     protected $_defaultConfig = [
-        'mode' => 'OR',
+        'mode' => null,
+        'fieldMode' => 'OR',
+        'valueMode' => 'OR',
     ];
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param string $name Name.
+     * @param \Search\Manager $manager Manager.
+     * @param array $config Config.
+     */
+    public function __construct($name, Manager $manager, array $config = [])
+    {
+        parent::__construct($name, $manager, $config);
+
+        $mode = $this->config('mode');
+        if ($mode !== null) {
+            $this->config('valueMode', $mode);
+        }
+    }
 
     /**
      * Process a value condition ($x == $y).
@@ -36,21 +58,27 @@ class Value extends Base
             return;
         }
 
-        $this->query()->andWhere(function ($e) use ($value, $isMultiValue) {
-            /* @var $e \Cake\Database\Expression\QueryExpression */
-            $field = $this->field();
+        $valueMode = strtoupper($this->config('valueMode'));
 
-            if (strtoupper($this->config('mode')) === 'OR' &&
-                $isMultiValue
-            ) {
-                return $e->in($field, $value);
-            }
+        $expressions = [];
+        foreach ($this->fields() as $field) {
+            $expressions[] = function (QueryExpression $e) use ($field, $value, $isMultiValue, $valueMode) {
+                if ($valueMode === 'OR' &&
+                    $isMultiValue
+                ) {
+                    return $e->in($field, $value);
+                }
 
-            foreach ((array)$value as $val) {
-                $e->eq($field, $val);
-            }
+                foreach ((array)$value as $val) {
+                    $e->eq($field, $val);
+                }
 
-            return $e;
-        });
+                return $e;
+            };
+        }
+
+        if (!empty($expressions)) {
+            $this->query()->andWhere([$this->config('fieldMode') => $expressions]);
+        }
     }
 }

--- a/src/Model/Filter/Value.php
+++ b/src/Model/Filter/Value.php
@@ -2,7 +2,6 @@
 namespace Search\Model\Filter;
 
 use Cake\Database\Expression\QueryExpression;
-use Search\Manager;
 
 class Value extends Base
 {
@@ -13,27 +12,8 @@ class Value extends Base
      * @var array
      */
     protected $_defaultConfig = [
-        'mode' => null,
-        'fieldMode' => 'OR',
-        'valueMode' => 'OR',
+        'mode' => 'OR'
     ];
-
-    /**
-     * {@inheritDoc}
-     *
-     * @param string $name Name.
-     * @param \Search\Manager $manager Manager.
-     * @param array $config Config.
-     */
-    public function __construct($name, Manager $manager, array $config = [])
-    {
-        parent::__construct($name, $manager, $config);
-
-        $mode = $this->config('mode');
-        if ($mode !== null) {
-            $this->config('valueMode', $mode);
-        }
-    }
 
     /**
      * Process a value condition ($x == $y).
@@ -58,27 +38,19 @@ class Value extends Base
             return;
         }
 
-        $valueMode = strtoupper($this->config('valueMode'));
-
         $expressions = [];
         foreach ($this->fields() as $field) {
-            $expressions[] = function (QueryExpression $e) use ($field, $value, $isMultiValue, $valueMode) {
-                if ($valueMode === 'OR' &&
-                    $isMultiValue
-                ) {
+            $expressions[] = function (QueryExpression $e) use ($field, $value, $isMultiValue) {
+                if ($isMultiValue) {
                     return $e->in($field, $value);
                 }
 
-                foreach ((array)$value as $val) {
-                    $e->eq($field, $val);
-                }
-
-                return $e;
+                return $e->eq($field, $value);
             };
         }
 
         if (!empty($expressions)) {
-            $this->query()->andWhere([$this->config('fieldMode') => $expressions]);
+            $this->query()->andWhere([$this->config('mode') => $expressions]);
         }
     }
 }

--- a/tests/TestCase/Model/Filter/ValueTest.php
+++ b/tests/TestCase/Model/Filter/ValueTest.php
@@ -22,20 +22,6 @@ class ValueTest extends TestCase
     /**
      * @return void
      */
-    public function testDeprecatedModeOption()
-    {
-        $articles = TableRegistry::get('Articles');
-        $manager = new Manager($articles);
-        $filter = new Value('title', $manager, ['mode' => 'modeValue']);
-
-        $this->assertEquals('modeValue', $filter->config('mode'));
-        $this->assertEquals('modeValue', $filter->config('valueMode'));
-        $this->assertEquals('OR', $filter->config('fieldMode'));
-    }
-
-    /**
-     * @return void
-     */
     public function testSkipProcess()
     {
         $articles = TableRegistry::get('Articles');
@@ -82,11 +68,11 @@ class ValueTest extends TestCase
     /**
      * @return void
      */
-    public function testProcessSingleValueWithAndValueMode()
+    public function testProcessSingleValueWithAndMode()
     {
         $articles = TableRegistry::get('Articles');
         $manager = new Manager($articles);
-        $filter = new Value('title', $manager, ['valueMode' => 'and']);
+        $filter = new Value('title', $manager, ['mode' => 'and']);
         $filter->args(['title' => 'foo']);
         $filter->query($articles->find());
         $filter->process();
@@ -104,13 +90,12 @@ class ValueTest extends TestCase
     /**
      * @return void
      */
-    public function testProcessSingleValueAndMultiFieldWithAndValueMode()
+    public function testProcessSingleValueAndMultiField()
     {
         $articles = TableRegistry::get('Articles');
         $manager = new Manager($articles);
         $filter = new Value('title', $manager, [
-            'field' => ['title', 'other'],
-            'valueMode' => 'and'
+            'field' => ['title', 'other']
         ]);
         $filter->args(['title' => 'foo']);
         $filter->query($articles->find());
@@ -129,13 +114,13 @@ class ValueTest extends TestCase
     /**
      * @return void
      */
-    public function testProcessSingleValueAndMultiFieldWithAndFieldMode()
+    public function testProcessSingleValueAndMultiFieldWithAndMode()
     {
         $articles = TableRegistry::get('Articles');
         $manager = new Manager($articles);
         $filter = new Value('title', $manager, [
             'field' => ['title', 'other'],
-            'fieldMode' => 'and'
+            'mode' => 'and'
         ]);
         $filter->args(['title' => 'foo']);
         $filter->query($articles->find());
@@ -176,20 +161,20 @@ class ValueTest extends TestCase
     /**
      * @return void
      */
-    public function testProcessMultiValueWithAndValueMode()
+    public function testProcessMultiValueWithAndMode()
     {
         $articles = TableRegistry::get('Articles');
         $manager = new Manager($articles);
         $filter = new Value('title', $manager, [
             'multiValue' => true,
-            'valueMode' => 'and'
+            'mode' => 'and'
         ]);
         $filter->args(['title' => ['foo', 'bar']]);
         $filter->query($articles->find());
         $filter->process();
 
         $this->assertRegExp(
-            '/WHERE \(Articles\.title = :c0 AND Articles\.title = :c1\)$/',
+            '/WHERE Articles\.title IN \(:c0,:c1\)$/',
             $filter->query()->sql()
         );
         $this->assertEquals(
@@ -227,14 +212,14 @@ class ValueTest extends TestCase
     /**
      * @return void
      */
-    public function testProcessMultiValueAndMultiFieldWithAndFieldMode()
+    public function testProcessMultiValueAndMultiFieldWithAndMode()
     {
         $articles = TableRegistry::get('Articles');
         $manager = new Manager($articles);
         $filter = new Value('title', $manager, [
             'multiValue' => true,
             'field' => ['title', 'other'],
-            'fieldMode' => 'and'
+            'mode' => 'and'
         ]);
         $filter->args(['title' => ['foo', 'bar']]);
         $filter->query($articles->find());
@@ -332,13 +317,13 @@ class ValueTest extends TestCase
     /**
      * @return void
      */
-    public function testProcessCaseInsensitiveValueMode()
+    public function testProcessCaseInsensitiveMode()
     {
         $articles = TableRegistry::get('Articles');
         $manager = new Manager($articles);
         $filter = new Value('title', $manager, [
             'multiValue' => true,
-            'valueMode' => 'Or'
+            'mode' => 'Or'
         ]);
         $filter->args(['title' => ['foo', 'bar']]);
         $filter->query($articles->find());


### PR DESCRIPTION
Basically a copy of #135, but complete with tests.

However, I've just noticed that having a mode for the values doesn't seem to make any sense, given that this filter applies an EQ comparison, applying AND to multiple values would never match, as a field can only hold one of the values in such a comparison.

Am I missing something, or did I just made a mistake when I added this initially, and nobody noticed it?