### PR TITLE
Api improvement for isSearch.

### DIFF
--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -214,10 +214,13 @@ class SearchBehavior extends Behavior
             $filter->setArgs($params);
             $filter->setQuery($query);
 
-            if (!$filter->skip()) {
+            if ($filter->skip()) {
+                continue;
+            }
+            $result = $filter->process();
+            if ($result !== false) {
                 $this->_isSearch = true;
             }
-            $filter->process();
         }
 
         return $query;

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -312,7 +312,7 @@ abstract class Base
      * Modify the actual query object and append conditions based on the
      * subclass business rules and type.
      *
-     * @return void
+     * @return bool True if processed, false if skipped
      */
     abstract public function process();
 }

--- a/src/Model/Filter/Boolean.php
+++ b/src/Model/Filter/Boolean.php
@@ -18,17 +18,13 @@ class Boolean extends Base
     /**
      * Check if a value is truthy/falsy and pass as condition.
      *
-     * @return void
+     * @return bool
      */
     public function process()
     {
-        if ($this->skip()) {
-            return;
-        }
-
         $value = $this->value();
         if (!is_scalar($value)) {
-            return;
+            return false;
         }
 
         if (is_string($value)) {
@@ -50,5 +46,7 @@ class Boolean extends Base
 
             $this->getQuery()->andWhere([$this->config('mode') => $conditions]);
         }
+
+        return true;
     }
 }

--- a/src/Model/Filter/Callback.php
+++ b/src/Model/Filter/Callback.php
@@ -7,14 +7,12 @@ class Callback extends Base
     /**
      * Modify query using callback.
      *
-     * @return void
+     * @return bool
      */
     public function process()
     {
-        if ($this->skip()) {
-            return;
-        }
-
         call_user_func($this->config('callback'), $this->getQuery(), $this->getArgs(), $this);
+
+        return true;
     }
 }

--- a/src/Model/Filter/Compare.php
+++ b/src/Model/Filter/Compare.php
@@ -26,14 +26,10 @@ class Compare extends Base
     /**
      * Process a comparison-based condition (e.g. $field <= $value).
      *
-     * @return void
+     * @return bool
      */
     public function process()
     {
-        if ($this->skip()) {
-            return;
-        }
-
         $conditions = [];
         if (!in_array($this->config('operator'), $this->_operators, true)) {
             throw new \InvalidArgumentException(sprintf('The operator %s is invalid!', $this->config('operator')));
@@ -41,7 +37,7 @@ class Compare extends Base
 
         $value = $this->value();
         if (!is_scalar($value)) {
-            return;
+            return false;
         }
 
         foreach ($this->fields() as $field) {
@@ -50,5 +46,7 @@ class Compare extends Base
         }
 
         $this->getQuery()->andWhere([$this->config('mode') => $conditions]);
+
+        return true;
     }
 }

--- a/src/Model/Filter/Finder.php
+++ b/src/Model/Filter/Finder.php
@@ -19,14 +19,12 @@ class Finder extends Base
     /**
      * Add a condition based on a custom finder.
      *
-     * @return void
+     * @return bool
      */
     public function process()
     {
-        if ($this->skip()) {
-            return;
-        }
-
         $this->getQuery()->find($this->finder(), (array)$this->getArgs());
+
+        return true;
     }
 }

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -53,14 +53,10 @@ class Like extends Base
     /**
      * Process a LIKE condition ($x LIKE $y).
      *
-     * @return void
+     * @return bool
      */
     public function process()
     {
-        if ($this->skip()) {
-            return;
-        }
-
         $this->_setEscaper();
         $comparison = $this->config('comparison');
         $valueMode = $this->config('valueMode');
@@ -97,6 +93,8 @@ class Like extends Base
 
             $this->getQuery()->andWhere([$this->config('fieldMode') => $conditions], $colTypes);
         }
+
+        return true;
     }
 
     /**

--- a/src/Model/Filter/Value.php
+++ b/src/Model/Filter/Value.php
@@ -18,24 +18,20 @@ class Value extends Base
     /**
      * Process a value condition ($x == $y).
      *
-     * @return void
+     * @return bool
      */
     public function process()
     {
-        if ($this->skip()) {
-            return;
-        }
-
         $value = $this->value();
         if ($value === null) {
-            return;
+            return false;
         }
 
         $isMultiValue = is_array($value);
         if ($isMultiValue &&
             empty($value)
         ) {
-            return;
+            return false;
         }
 
         $expressions = [];
@@ -49,6 +45,10 @@ class Value extends Base
             };
         }
 
-        $this->getQuery()->andWhere([$this->config('mode') => $expressions]);
+        if (!empty($expressions)) {
+            $this->getQuery()->andWhere([$this->config('mode') => $expressions]);
+        }
+
+        return true;
     }
 }

--- a/src/Model/Filter/Value.php
+++ b/src/Model/Filter/Value.php
@@ -45,9 +45,7 @@ class Value extends Base
             };
         }
 
-        if (!empty($expressions)) {
-            $this->getQuery()->andWhere([$this->config('mode') => $expressions]);
-        }
+        $this->getQuery()->andWhere([$this->config('mode') => $expressions]);
 
         return true;
     }

--- a/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
@@ -83,7 +83,7 @@ class SearchBehaviorTest extends TestCase
         $filter = $this
             ->getMockBuilder('\Search\Test\TestApp\Model\Filter\TestFilter')
             ->setConstructorArgs(['name', new Manager($this->Comments)])
-            ->setMethods(['setArgs', 'process', 'setQuery'])
+            ->setMethods(['setArgs', 'skip', 'process', 'setQuery'])
             ->getMock();
         $filter
             ->expects($this->at(0))
@@ -93,6 +93,9 @@ class SearchBehaviorTest extends TestCase
             ->expects($this->at(1))
             ->method('setQuery')
             ->with($query);
+        $filter
+            ->expects($this->at(2))
+            ->method('skip');
         $filter
             ->expects($this->at(2))
             ->method('process');

--- a/tests/TestCase/Model/Filter/BooleanTest.php
+++ b/tests/TestCase/Model/Filter/BooleanTest.php
@@ -22,30 +22,6 @@ class BooleanTest extends TestCase
     /**
      * @return void
      */
-    public function testSkipProcess()
-    {
-        $articles = TableRegistry::get('Articles');
-        $manager = new Manager($articles);
-        /* @var $filter \Search\Model\Filter\Boolean|\PHPUnit_Framework_MockObject_MockObject */
-        $filter = $this
-            ->getMockBuilder('Search\Model\Filter\Boolean')
-            ->setConstructorArgs(['is_active', $manager])
-            ->setMethods(['skip'])
-            ->getMock();
-        $filter
-            ->expects($this->once())
-            ->method('skip')
-            ->willReturn(true);
-        $filter->args(['is_active' => true]);
-        $filter->query($articles->find());
-        $filter->process();
-
-        $this->assertEmpty($filter->query()->clause('where'));
-    }
-
-    /**
-     * @return void
-     */
     public function testProcessWithFlagOn()
     {
         $articles = TableRegistry::get('Articles');

--- a/tests/TestCase/Model/Filter/CallbackTest.php
+++ b/tests/TestCase/Model/Filter/CallbackTest.php
@@ -23,30 +23,6 @@ class CallbackTest extends TestCase
     /**
      * @return void
      */
-    public function testSkipProcess()
-    {
-        $articles = TableRegistry::get('Articles');
-        $manager = new Manager($articles);
-        /* @var $filter \Search\Model\Filter\Callback|\PHPUnit_Framework_MockObject_MockObject */
-        $filter = $this
-            ->getMockBuilder('Search\Model\Filter\Callback')
-            ->setConstructorArgs(['title', $manager])
-            ->setMethods(['skip'])
-            ->getMock();
-        $filter
-            ->expects($this->once())
-            ->method('skip')
-            ->willReturn(true);
-        $filter->args(['title' => 'test']);
-        $filter->query($articles->find());
-        $filter->process();
-
-        $this->assertEmpty($filter->query()->clause('where'));
-    }
-
-    /**
-     * @return void
-     */
     public function testProcess()
     {
         $articles = TableRegistry::get('Articles');

--- a/tests/TestCase/Model/Filter/CompareTest.php
+++ b/tests/TestCase/Model/Filter/CompareTest.php
@@ -22,30 +22,6 @@ class CompareTest extends TestCase
     /**
      * @return void
      */
-    public function testSkipProcess()
-    {
-        $articles = TableRegistry::get('Articles');
-        $manager = new Manager($articles);
-        /* @var $filter \Search\Model\Filter\Compare|\PHPUnit_Framework_MockObject_MockObject */
-        $filter = $this
-            ->getMockBuilder('Search\Model\Filter\Compare')
-            ->setConstructorArgs(['created', $manager])
-            ->setMethods(['skip'])
-            ->getMock();
-        $filter
-            ->expects($this->once())
-            ->method('skip')
-            ->willReturn(true);
-        $filter->args(['created' => '2012-01-01 00:00:00']);
-        $filter->query($articles->find());
-        $filter->process();
-
-        $this->assertEmpty($filter->query()->clause('where'));
-    }
-
-    /**
-     * @return void
-     */
     public function testProcess()
     {
         $articles = TableRegistry::get('Articles');

--- a/tests/TestCase/Model/Filter/FinderTest.php
+++ b/tests/TestCase/Model/Filter/FinderTest.php
@@ -22,30 +22,6 @@ class FinderTest extends TestCase
     /**
      * @return void
      */
-    public function testSkipProcess()
-    {
-        $articles = TableRegistry::get('Articles');
-        $manager = new Manager($articles);
-        /* @var $filter \Search\Model\Filter\Finder|\PHPUnit_Framework_MockObject_MockObject */
-        $filter = $this
-            ->getMockBuilder('Search\Model\Filter\Finder')
-            ->setConstructorArgs(['title', $manager])
-            ->setMethods(['skip'])
-            ->getMock();
-        $filter
-            ->expects($this->once())
-            ->method('skip')
-            ->willReturn(true);
-        $filter->args(['title' => 'test']);
-        $filter->query($articles->find());
-        $filter->process();
-
-        $this->assertEmpty($filter->query()->clause('where'));
-    }
-
-    /**
-     * @return void
-     */
     public function testProcess()
     {
         $articles = TableRegistry::get('FinderArticles', [

--- a/tests/TestCase/Model/Filter/LikeTest.php
+++ b/tests/TestCase/Model/Filter/LikeTest.php
@@ -36,30 +36,6 @@ class LikeTest extends TestCase
     /**
      * @return void
      */
-    public function testSkipProcess()
-    {
-        $articles = TableRegistry::get('Articles');
-        $manager = new Manager($articles);
-        /* @var $filter \Search\Model\Filter\Like|\PHPUnit_Framework_MockObject_MockObject */
-        $filter = $this
-            ->getMockBuilder('Search\Model\Filter\Like')
-            ->setConstructorArgs(['title', $manager])
-            ->setMethods(['skip'])
-            ->getMock();
-        $filter
-            ->expects($this->once())
-            ->method('skip')
-            ->willReturn(true);
-        $filter->args(['title' => 'test']);
-        $filter->query($articles->find()->select(['id']));
-        $filter->process();
-
-        $this->assertEmpty($filter->query()->clause('where'));
-    }
-
-    /**
-     * @return void
-     */
     public function testProcess()
     {
         $articles = TableRegistry::get('Articles');

--- a/tests/TestCase/Model/Filter/ValueTest.php
+++ b/tests/TestCase/Model/Filter/ValueTest.php
@@ -22,30 +22,6 @@ class ValueTest extends TestCase
     /**
      * @return void
      */
-    public function testSkipProcess()
-    {
-        $articles = TableRegistry::get('Articles');
-        $manager = new Manager($articles);
-        /* @var $filter \Search\Model\Filter\Value|\PHPUnit_Framework_MockObject_MockObject */
-        $filter = $this
-            ->getMockBuilder('Search\Model\Filter\Value')
-            ->setConstructorArgs(['title', $manager])
-            ->setMethods(['skip'])
-            ->getMock();
-        $filter
-            ->expects($this->once())
-            ->method('skip')
-            ->willReturn(true);
-        $filter->args(['title' => 'test']);
-        $filter->query($articles->find());
-        $filter->process();
-
-        $this->assertEmpty($filter->query()->clause('where'));
-    }
-
-    /**
-     * @return void
-     */
     public function testProcess()
     {
         $articles = TableRegistry::get('Articles');


### PR DESCRIPTION
After be just bumped the major, I think this should also land in that new version.
It is BC - and improves the API by clearly returning a bool result on process() to indicated if a search filter has been actually applied.
It also simplifies the code since skip() doesnt need to be invoked twice.