### PR TITLE
Split combined setters/getters for cleaner API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ All you need to do is:
 ```php
 // ExampleTable::initialize()
     $this->searchManager()
-        ->collection('backend')
+        ->useCollection('backend')
         ->add('q', 'Search.Like', [
             'before' => true,
             'after' => true,
@@ -345,7 +345,7 @@ All you need to do is:
             'wildcardOne' => '?',
             'field' => ['body']
         ])
-        ->collection('frontend')
+        ->useCollection('frontend')
         ->value('name');
 ```
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -127,10 +127,10 @@ class Manager
     public function collection($name = null)
     {
         if ($name === null) {
-            return $this->useCollection();
+            return $this->getCollection();
         }
 
-        return $this->setCollection($name);
+        return $this->useCollection($name);
     }
 
     /**

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -65,12 +65,12 @@ class Manager
     /**
      * Return Table
      *
-     * @return \Cake\ORM\Table Table Instance
+     * @return \Cake\Datasource\RepositoryInterface Repository Instance
      * @deprecated Use repository() instead.
      */
     public function table()
     {
-        return $this->_repository;
+        return $this->repository();
     }
 
     /**
@@ -92,23 +92,45 @@ class Manager
     }
 
     /**
-     * Sets or gets the filter collection name.
+     * Sets the filter collection name to use.
      *
-     * @param string|null $name Name of the active filter collection to set.
-     * @return mixed Returns $this or the name of the active collection if no $name was provided.
+     * @param string $name Name of the active filter collection to set.
+     * @return $this
      */
-    public function collection($name = null)
+    public function useCollection($name)
     {
-        if ($name === null) {
-            return $this->_collection;
-        }
-
         if (!isset($this->_filters[$name])) {
             $this->_filters[$name] = [];
         }
         $this->_collection = $name;
 
         return $this;
+    }
+
+    /**
+     * Sets or gets the filter collection name.
+     *
+     * @return string The name of the active collection.
+     */
+    public function getCollection()
+    {
+        return $this->_collection;
+    }
+
+    /**
+     * Sets or gets the filter collection name.
+     *
+     * @deprecated 3.0.0 Use addCollection()/getCollection() instead.
+     * @param string|null $name Name of the active filter collection to set.
+     * @return string|$this Returns $this or the name of the active collection if no $name was provided.
+     */
+    public function collection($name = null)
+    {
+        if ($name === null) {
+            return $this->useCollection();
+        }
+
+        return $this->setCollection($name);
     }
 
     /**

--- a/tests/TestApp/Model/Table/GroupsTable.php
+++ b/tests/TestApp/Model/Table/GroupsTable.php
@@ -15,9 +15,9 @@ class GroupsTable extends Table
         $manager = new Manager($this);
 
         return $manager
-            ->collection('frontend')
+            ->useCollection('frontend')
             ->value('title')
-            ->collection('backend')
+            ->useCollection('backend')
             ->like('title', ['before' => true, 'after' => true]);
     }
 }

--- a/tests/TestCase/ManagerTest.php
+++ b/tests/TestCase/ManagerTest.php
@@ -243,4 +243,21 @@ class ManagerTest extends TestCase
         $this->assertArrayHasKey('test2', $result);
         $this->assertArrayHasKey('test3', $result);
     }
+
+    /**
+     * @deprecated Remove with next major.
+     * @return void
+     */
+    public function testCollectionCombined()
+    {
+        $table = TableRegistry::get('Articles');
+        $manager = new Manager($table);
+
+        $result = $manager->collection();
+        $this->assertEquals('default', $result);
+
+        $result = $manager->collection('default');
+        $this->assertInstanceOf('\Search\Manager', $result);
+    }
+
 }

--- a/tests/TestCase/ManagerTest.php
+++ b/tests/TestCase/ManagerTest.php
@@ -89,11 +89,11 @@ class ManagerTest extends TestCase
 
         $this->assertEmpty($manager->all());
 
-        $manager->collection('other');
+        $manager->useCollection('other');
         $manager->add('field', 'Search.Value');
         $this->assertEmpty($manager->all());
 
-        $manager->collection('default');
+        $manager->useCollection('default');
         $manager->add('field', 'Search.Value');
         $all = $manager->all();
         $this->assertCount(1, $all);
@@ -222,14 +222,14 @@ class ManagerTest extends TestCase
         $table = TableRegistry::get('Articles');
         $manager = new Manager($table);
 
-        $result = $manager->collection();
+        $result = $manager->getCollection();
         $this->assertEquals('default', $result);
 
-        $result = $manager->collection('default');
+        $result = $manager->useCollection('default');
         $this->assertInstanceOf('\Search\Manager', $result);
 
         $manager->add('test', 'Search.Value');
-        $result = $manager->collection('otherFilters');
+        $result = $manager->useCollection('otherFilters');
         $this->assertInstanceOf('\Search\Manager', $result);
 
         $manager->add('test2', 'Search.Value');

--- a/tests/TestCase/ManagerTest.php
+++ b/tests/TestCase/ManagerTest.php
@@ -259,5 +259,4 @@ class ManagerTest extends TestCase
         $result = $manager->collection('default');
         $this->assertInstanceOf('\Search\Manager', $result);
     }
-
 }


### PR DESCRIPTION
Continue https://github.com/FriendsOfCake/search/pull/165

The different return types of useCollection() vs getCollection is especially important to clean up here.