### PR TITLE
Allow passing un-flattened params to filters (closes #170)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,11 @@ The following options are supported by all filters.
   run in case the corresponding field in the request is empty. Refer to
   [the Optional fields section](#optional-fields) for additional details.
 
+- `flatten` (`bool`, defaults to `true`) Defines whether values passed from the
+  the input form as arrays should be flattened. If the structure of the value array
+  should be maintained to ease parsing the passed data with your chosen filter,
+  set this to `false`.
+
 The following options are supported by all filters except `Callback` and `Finder`.
 
 - `aliasField` (`bool`, defaults to `true`) Defines whether the field name should

--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -166,7 +166,7 @@ class SearchBehavior extends Behavior
     {
         $flattened = [];
         foreach ($params as $key => $value) {
-            if (is_array($value) && !empty($filters[$key]) && $filters[$key]->getConfig()['flatten'] == false) {
+            if (is_array($value) && !empty($filters[$key]) && $filters[$key]->getConfig()['flatten'] === false) {
                 $flattened[$key] = $value;
                 continue;
             }

--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -166,21 +166,23 @@ class SearchBehavior extends Behavior
     {  
         $flattened = [];
         foreach ($params as $key => $value) {
+            if (is_array($value) && !empty($filters[$key]) && $filters[$key]->getConfig()['flatten'] == false) {
+                $flattened[$key] = $value;
+                continue;
+            }
+            
             if (is_array($value)) {
-                if (!empty($filters[$key]) && $filters[$key]->getConfig()['flatten'] == false) {
-                    $flattened[$key] = $value;
-                } else {
-                    foreach ($value as $childKey => $childValue) {
-                        if (!is_numeric($childKey)) {
-                            $flattened[$key . '.' . $childKey] = $childValue;
-                        } else {
-                            $flattened[$key][$childKey] = $childValue;
-                        }
+                foreach ($value as $childKey => $childValue) {
+                    if (!is_numeric($childKey)) {
+                        $flattened[$key . '.' . $childKey] = $childValue;
+                    } else {
+                        $flattened[$key][$childKey] = $childValue;
                     }
                 }
-            } else {
-                $flattened[$key] = $value;
+                continue;
             }
+            
+            $flattened[$key] = $value;
         }
 
         return $flattened;

--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -62,9 +62,9 @@ class SearchBehavior extends Behavior
                 'to be nested under key "search" in find() options.'
             );
         }
-        
+
         $filters = $this->_getAllFilters(Hash::get($options, 'collection', 'default'));
-  
+
         $params = $this->_flattenParams((array)$options['search'], $filters);
         $params = $this->_extractParams($params, $filters);
 
@@ -163,26 +163,26 @@ class SearchBehavior extends Behavior
      * @return array The flattened parameters array.
      */
     protected function _flattenParams($params, $filters)
-    {  
+    {
         $flattened = [];
         foreach ($params as $key => $value) {
             if (is_array($value) && !empty($filters[$key]) && $filters[$key]->getConfig()['flatten'] == false) {
                 $flattened[$key] = $value;
                 continue;
             }
-            
-            if (is_array($value)) {
-                foreach ($value as $childKey => $childValue) {
-                    if (!is_numeric($childKey)) {
-                        $flattened[$key . '.' . $childKey] = $childValue;
-                    } else {
-                        $flattened[$key][$childKey] = $childValue;
-                    }
-                }
+
+            if (!is_array($value)) {
+                $flattened[$key] = $value;
                 continue;
             }
-            
-            $flattened[$key] = $value;
+
+            foreach ($value as $childKey => $childValue) {
+                if (!is_numeric($childKey)) {
+                    $flattened[$key . '.' . $childKey] = $childValue;
+                } else {
+                    $flattened[$key][$childKey] = $childValue;
+                }
+            }
         }
 
         return $flattened;

--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -166,15 +166,9 @@ class SearchBehavior extends Behavior
     {
         $flattened = [];
         foreach ($params as $key => $value) {
-            if (is_array($value)
-                && !empty($filters[$key])
-                && $filters[$key]->config()['flatten'] === false
+            if (!is_array($value) ||
+                (!empty($filters[$key]) && $filters[$key]->config()['flatten'] === false)
             ) {
-                $flattened[$key] = $value;
-                continue;
-            }
-
-            if (!is_array($value)) {
                 $flattened[$key] = $value;
                 continue;
             }

--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -65,13 +65,11 @@ class SearchBehavior extends Behavior
         
         $filters = $this->_getAllFilters(Hash::get($options, 'collection', 'default'));
 
-        $flattenWhitelist = []; //TODO FIXME should this actually be an array?
+        $flattenWhitelist = [];
         foreach($filters as $filter) {
             $config = $filter->getConfig();
-            if (!empty($config['flattenWhitelist'])) {
-                foreach ($config['flattenWhitelist'] as $entry) {
-                    array_push($flattenWhitelist, $entry);
-                }
+            if (isset($config['flatten']) && $config['flatten'] === false) {             
+                array_push($flattenWhitelist, $config['name']);
             }
         }
         
@@ -169,7 +167,7 @@ class SearchBehavior extends Behavior
      * ```
      *
      * @param array $params The parameters array to flatten.
-     * @param array $flattenWhitelist array keys to avoid flattening.
+     * @param array $flattenWhitelist Keys to avoid flattening.
      * @return array The flattened parameters array.
      */
     protected function _flattenParams($params, $flattenWhitelist)

--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -64,16 +64,8 @@ class SearchBehavior extends Behavior
         }
         
         $filters = $this->_getAllFilters(Hash::get($options, 'collection', 'default'));
-
-        $flattenWhitelist = [];
-        foreach($filters as $filter) {
-            $config = $filter->getConfig();
-            if (isset($config['flatten']) && $config['flatten'] === false) {             
-                array_push($flattenWhitelist, $config['name']);
-            }
-        }
-        
-        $params = $this->_flattenParams((array)$options['search'], $flattenWhitelist);
+  
+        $params = $this->_flattenParams((array)$options['search'], $filters);
         $params = $this->_extractParams($params, $filters);
 
         return $this->_processFilters($filters, $params, $query);
@@ -167,14 +159,14 @@ class SearchBehavior extends Behavior
      * ```
      *
      * @param array $params The parameters array to flatten.
-     * @param array $flattenWhitelist Keys to avoid flattening.
+     * @param array $filters The array of filters with configuration
      * @return array The flattened parameters array.
      */
-    protected function _flattenParams($params, $flattenWhitelist)
-    {
+    protected function _flattenParams($params, $filters)
+    {  
         $flattened = [];
         foreach ($params as $key => $value) {
-            if (is_array($value) && !in_array($key, $flattenWhitelist)) {
+            if (is_array($value) && !empty($filters[$key]) && $filters[$key]->getConfig()['flatten'] == true) {
                 foreach ($value as $childKey => $childValue) {
                     if (!is_numeric($childKey)) {
                         $flattened[$key . '.' . $childKey] = $childValue;

--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -166,7 +166,10 @@ class SearchBehavior extends Behavior
     {
         $flattened = [];
         foreach ($params as $key => $value) {
-            if (is_array($value) && !empty($filters[$key]) && $filters[$key]->getConfig()['flatten'] === false) {
+            if (is_array($value)
+                && !empty($filters[$key])
+                && $filters[$key]->config()['flatten'] === false
+            ) {
                 $flattened[$key] = $value;
                 continue;
             }

--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -166,12 +166,16 @@ class SearchBehavior extends Behavior
     {  
         $flattened = [];
         foreach ($params as $key => $value) {
-            if (is_array($value) && !empty($filters[$key]) && $filters[$key]->getConfig()['flatten'] == true) {
-                foreach ($value as $childKey => $childValue) {
-                    if (!is_numeric($childKey)) {
-                        $flattened[$key . '.' . $childKey] = $childValue;
-                    } else {
-                        $flattened[$key][$childKey] = $childValue;
+            if (is_array($value)) {
+                if (!empty($filters[$key]) && $filters[$key]->getConfig()['flatten'] == false) {
+                    $flattened[$key] = $value;
+                } else {
+                    foreach ($value as $childKey => $childValue) {
+                        if (!is_numeric($childKey)) {
+                            $flattened[$key . '.' . $childKey] = $childValue;
+                        } else {
+                            $flattened[$key][$childKey] = $childValue;
+                        }
                     }
                 }
             } else {

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -65,6 +65,7 @@ abstract class Base
             'filterEmpty' => false,
             'defaultValue' => null,
             'multiValue' => false,
+            'flatten' => true,
         ];
         $config += $defaults;
         $this->config($config);

--- a/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
@@ -75,16 +75,21 @@ class SearchBehaviorTest extends TestCase
             'className' => '\\' . get_class($behavior)
         ]);
 
-        $params = [
-            'name' => 'value'
-        ];
         $query = $this->Comments->find();
 
         $filter = $this
             ->getMockBuilder('\Search\Test\TestApp\Model\Filter\TestFilter')
-            ->setConstructorArgs(['name', new Manager($this->Comments)])
+            ->setConstructorArgs(['name', new Manager($this->Comments), ['flatten' => false]])
             ->setMethods(['setArgs', 'skip', 'process', 'setQuery'])
             ->getMock();
+
+        $params = [
+            'name' => [
+                'one' => 'foo',
+                'two' => 'bar'
+            ]
+        ];
+
         $filter
             ->expects($this->at(0))
             ->method('setArgs')
@@ -112,14 +117,33 @@ class SearchBehaviorTest extends TestCase
             ->with('default')
             ->willReturn($filters);
 
+        $queryString = [
+            'name' => [
+                'one' => 'foo',
+                'two' => 'bar'
+            ],
+            'key' => [
+                'one' => 'foo',
+                'two' => 'bar'
+            ],
+            'string' => 'text'
+        ];
+
+        $flattenedQueryString = [
+            'name' => [
+                'one' => 'foo',
+                'two' => 'bar'
+            ],
+            'key.one' => 'foo',
+            'key.two' => 'bar',
+            'string' => 'text'
+        ];
+
         $behavior
             ->expects($this->once())
             ->method('_flattenParams')
-            ->willReturn($params);
+            ->willReturn($flattenedQueryString);
 
-        $queryString = [
-            'name' => 'value'
-        ];
         $behavior->findSearch($query, ['search' => $queryString]);
     }
 

--- a/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
@@ -68,7 +68,7 @@ class SearchBehaviorTest extends TestCase
         $behavior = $this
             ->getMockBuilder('Search\Model\Behavior\SearchBehavior')
             ->setConstructorArgs([$this->Comments])
-            ->setMethods(['_getAllFilters'])
+            ->setMethods(['_getAllFilters', '_flattenParams'])
             ->getMock();
         $this->Comments->behaviors()->reset();
         $this->Comments->addBehavior('Search', [
@@ -111,6 +111,11 @@ class SearchBehaviorTest extends TestCase
             ->method('_getAllFilters')
             ->with('default')
             ->willReturn($filters);
+
+        $behavior
+            ->expects($this->once())
+            ->method('_flattenParams')
+            ->willReturn($params);
 
         $queryString = [
             'name' => 'value'


### PR DESCRIPTION
This allows filters to deal with dates in the default way the CakePHP FormHelper delivers them, ie:
```php
$dateInRequest = [
    'someDate' => [
        'year' => '2014',
        'month' => '01',
        'day' => '13'
    ]
];
```
which lets me configure my filter like so:
```php
$this->searchManager() ->add('start_date', 'Search.Callback', [
    'flatten' => false,
    'callback' => function ($query, $args, $filter) {
        $arrayKeysExist = function (array $keys, array $arr) {
            return !array_diff_key(array_flip($keys), $arr);
        };

        $parts = $args[$filter->getConfig()['name']];
        if ($arrayKeysExist(['year', 'month', 'day'], $parts)) {
            $startDate = new Time(date('Y-m-d', strtotime('now')));
            $timestamp = $startDate->year($parts['year'])->month($parts['month'])->day($parts['day'])->toUnixString();
            $query->where([
                'UNIX_TIMESTAMP(Timesheets.start_time) >' => $timestamp
            ]);
        }
        return $query;
    }
```
Likewise I can go on to write a class for filtering dates like this, but this is a good proof of concept.