### PR TITLE
Revert invalid change and remove unneeded extra annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,7 @@ class ExampleTable extends Table
      */
     public function searchManager()
     {
-        /** @var \Search\Manager $searchManager */
-        $searchManager = $this->behaviors()->get('Search')->searchManager();
+        $searchManager = $this->behaviors()->Search->searchManager();
         $searchManager
             ->like('title')
             ->value('status');


### PR DESCRIPTION
Refs https://github.com/FriendsOfCake/search/pull/183#issuecomment-332667580

This is the correct way that works together with the IDE
Only bad magic, that does not help the developer is evil. In this case the evil is the get + magic string that will result in "mixed" return type and then completely kills the typehinting.
With basic annotating/codecompletion file the property works perfectly, see PR https://github.com/dereuromark/cakephp-ide-helper/pull/56 .
That is how developers are actually getting helped in coding :) not be using get() that will never work.