### PR TITLE
 Allow callback filter to specify process() return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ can instead add a `searchManager()` method to the table class and return a searc
 manager instance.
 
 ```php
-class ExampleTable extends Table 
+class ExampleTable extends Table
 {
     /**
      * @param array $config
@@ -111,7 +111,7 @@ class ExampleTable extends Table
         // Add the behaviour to your table
         $this->addBehavior('Search.Search');
     }
-    
+
     /**
      * @return \Search\Manager
      */
@@ -231,7 +231,7 @@ easily create the search results you need. Use:
 - `Finder` to produce results using a [(custom)](http://book.cakephp.org/3.0/en/orm/retrieving-data-and-resultsets.html#custom-find-methods) finder
 - `Compare` to produce results requiring operator comparison (
     `>`, `<`, `>=` and `<=`)
-- `Callback` to produce results using your own custom callable function
+- `Callback` to produce results using your own custom callable function, it should return bool to specify `isSearch()` (useful when using with `alwaysRun` enabled)
 
 ### Options
 

--- a/src/Model/Filter/Callback.php
+++ b/src/Model/Filter/Callback.php
@@ -11,7 +11,8 @@ class Callback extends Base
      */
     public function process()
     {
-        $ret = call_user_func($this->getConfig('callback'),
+        $ret = call_user_func(
+            $this->getConfig('callback'),
             $this->getQuery(),
             $this->getArgs(),
             $this
@@ -19,6 +20,7 @@ class Callback extends Base
         if ($ret === null) {
             return true;
         }
+
         return $ret;
     }
 }

--- a/src/Model/Filter/Callback.php
+++ b/src/Model/Filter/Callback.php
@@ -11,8 +11,14 @@ class Callback extends Base
      */
     public function process()
     {
-        call_user_func($this->getConfig('callback'), $this->getQuery(), $this->getArgs(), $this);
-
-        return true;
+        $ret = call_user_func($this->getConfig('callback'),
+            $this->getQuery(),
+            $this->getArgs(),
+            $this
+        );
+        if ($ret === null) {
+            return true;
+        }
+        return $ret;
     }
 }

--- a/tests/TestCase/Model/Filter/CallbackTest.php
+++ b/tests/TestCase/Model/Filter/CallbackTest.php
@@ -35,7 +35,7 @@ class CallbackTest extends TestCase
         ]);
         $filter->setArgs(['title' => ['test']]);
         $filter->setQuery($articles->find());
-        $filter->process();
+        $this->assertTrue($filter->process());
 
         $this->assertRegExp(
             '/WHERE title = \:c0$/',
@@ -45,5 +45,23 @@ class CallbackTest extends TestCase
             ['test'],
             Hash::extract($filter->getQuery()->valueBinder()->bindings(), '{s}.value')
         );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessFalse()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+
+        $filter = new Callback('title', $manager, [
+            'callback' => function (Query $query, array $args, Callback $filter) {
+                return false;
+            }
+        ]);
+        $filter->setArgs(['title' => ['test']]);
+        $filter->setQuery($articles->find());
+        $this->assertFalse($filter->process());
     }
 }


### PR DESCRIPTION
See #186

I return true on void functions for backwards compatibility.

Also mention callback return value in README.md although I'm no native speaker, so it needs review or maybe reword