### PR TITLE
Allow _isSearch auto populate

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,9 @@ The array passed to `FormHelper::create()` will cause the helper to create an
 query params.
 
 #### Adding a reset button dynamically
-Since the Prg component will pass down the information on whether the query was modified by your
-search query string, you can also include a reset button only if necessary:
+The Prg component will pass down the information on whether the query was modified by your
+search query string by setting `$_isSearch` view variable to true here in this case.
+This way you can include a reset button only if necessary:
 ```php
 // in your form
 if (!empty($_isSearch)) {

--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ The array passed to `FormHelper::create()` will cause the helper to create an
 query params.
 
 #### Adding a reset button dynamically
-Since the Prg component can pass down the information on whether the query was modified by your
-search query strings, you can also include a reset button only if necessary:
+Since the Prg component will pass down the information on whether the query was modified by your
+search query string, you can also include a reset button only if necessary:
 ```php
 // in your form
 if (!empty($_isSearch)) {

--- a/README.md
+++ b/README.md
@@ -214,18 +214,11 @@ The array passed to `FormHelper::create()` will cause the helper to create an
 query params.
 
 #### Adding a reset button dynamically
-If you pass down the information on whether the query was modified by your
+Since the Prg component can pass down the information on whether the query was modified by your
 search query strings, you can also include a reset button only if necessary:
-
-```php
-// in your controller action
-$this->set('isSearch', $this->Articles->isSearch());
-```
-
-Then one can switch based on that in the template:
 ```php
 // in your form
-if ($isSearch) {
+if (!empty($_isSearch)) {
     echo $this->Html->link('Reset', ['action' => 'index']);
 }
 ```

--- a/src/Controller/Component/PrgComponent.php
+++ b/src/Controller/Component/PrgComponent.php
@@ -20,6 +20,7 @@ class PrgComponent extends Component
      *   (will not be passed along in the URL).
      * - `modelClass` : Configure the controller's modelClass to be used for the query, used to
      *   populate the _isSearch view variable to allow for a reset button, for example.
+     *   Set to false to disable the auto-setting of the view variable.
      *
      * @var array
      */

--- a/src/Controller/Component/PrgComponent.php
+++ b/src/Controller/Component/PrgComponent.php
@@ -63,18 +63,23 @@ class PrgComponent extends Component
      */
     public function beforeRender()
     {
+        if (!$this->_actionCheck()) {
+            return null;
+        }
+
         $controller = $this->_registry->getController();
         $modelClass = $this->getConfig('modelClass', $controller->modelClass);
         if (!$modelClass) {
             return null;
         }
 
-        if (!isset($controller->{$modelClass})) {
+        list (, $modelName) = pluginSplit($modelClass);
+        if (!isset($controller->{$modelName})) {
             return null;
         }
 
         /* @var \Cake\ORM\Table|\Search\Model\Behavior\SearchBehavior $model */
-        $model = $controller->{$modelClass};
+        $model = $controller->{$modelName};
         if (!$model->behaviors()->has('Search')) {
             return null;
         }

--- a/src/Controller/Component/PrgComponent.php
+++ b/src/Controller/Component/PrgComponent.php
@@ -73,7 +73,7 @@ class PrgComponent extends Component
             return null;
         }
 
-        /** @var \Cake\ORM\Table|\Search\Model\Behavior\SearchBehavior $model */
+        /* @var \Cake\ORM\Table|\Search\Model\Behavior\SearchBehavior $model */
         $model = $controller->{$modelClass};
         if (!$model->behaviors()->has('Search')) {
             return null;

--- a/tests/TestCase/Controller/Component/PrgComponentTest.php
+++ b/tests/TestCase/Controller/Component/PrgComponentTest.php
@@ -224,7 +224,7 @@ class SearchComponentTest extends TestCase
             'controller' => 'Articles',
             'action' => 'index',
         ];
-        $this->Controller->modelClass = 'Articles';
+        $this->Controller->modelClass = 'SomePlugin.Articles';
         $this->Controller->Articles = $this->getMockBuilder(Table::class)->setMethods(['isSearch'])->getMock();
         $this->Controller->Articles->addBehavior('Search.Search');
         $this->Controller->Articles->expects($this->once())->method('isSearch')->willReturn(true);


### PR DESCRIPTION
So far you always had to manually add this in every single controller:
```php
    $this->set('_isSearch', $this->Capabilities->isSearch());
```
To allow for 
```php
    if (!empty($_isSearch)) {
        echo $this->Html->link('Reset', ['action' => 'index'], ['class' => 'button']);
    }
```

With the component easily being able to do that by default for the conventional way, this will simplify quite a bit the code here.
You can also configure it, or even disable it completely by passing e.g. false.

What do you think?