### PR TITLE
Finder map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 phpunit.xml
 composer.lock
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ before_script:
 
   - composer install
 
-  - if [[ $PHPCS = 1 ]]; then composer require cakephp/cakephp-codesniffer:"2.*"; fi
   - if [[ $PHPSTAN = 1 ]]; then composer require phpstan/phpstan; fi
 
   - if [[ $DB = 'mysql' ]]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.0 ]]; then vendor/bin/phpunit; fi
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.0 ]]; then vendor/bin/phpunit --coverage-clover=clover.xml; fi
 
-  - if [[ $PHPCS = 1 ]]; then vendor/bin/phpcs -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi
+  - if [[ $PHPCS = 1 ]]; then composer cs-check; fi
   - if [[ $PHPSTAN = 1 ]]; then vendor/bin/phpstan analyse -l 1 src; fi
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ The following options are supported by all filters except `Callback` and `Finder
 #### `Finder`
 
 - `finder` (`string`) The [find type](https://book.cakephp.org/3.0/en/orm/retrieving-data-and-resultsets.html#custom-finder-methods) to use.
+  Use the `map` config array if you need to map your field to a finder key (`'from_field' => 'to_field'`).
 
 ## Filter collections
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ The following options are supported by all filters except `Callback` and `Finder
 #### `Finder`
 
 - `finder` (`string`) The [find type](https://book.cakephp.org/3.0/en/orm/retrieving-data-and-resultsets.html#custom-finder-methods) to use.
-  Use the `map` config array if you need to map your field to a finder key (`'from_field' => 'to_field'`).
+  Use the `map` config array if you need to map your field to a finder key (`'to_field' => 'from_field'`).
 
 ## Filter collections
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     },
     "require-dev": {
         "friendsofcake/cakephp-test-utilities": "dev-master",
-        "phpunit/phpunit": "<6.0"
+        "phpunit/phpunit": "<6.0",
+        "cakephp/cakephp-codesniffer": "^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -44,5 +45,8 @@
         "source": "https://github.com/FriendsOfCake/search",
         "issues": "https://github.com/FriendsOfCake/search/issues",
         "irc": "irc://irc.freenode.org/friendsofcake"
+    },
+    "scripts": {
+        "cs-check": "vendor/bin/phpcs -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests"
     }
 }

--- a/src/Model/Filter/Finder.php
+++ b/src/Model/Filter/Finder.php
@@ -3,6 +3,12 @@ namespace Search\Model\Filter;
 
 class Finder extends Base
 {
+    /**
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'map' => [],
+    ];
 
     /**
      * Returns the finder method to use.
@@ -23,7 +29,13 @@ class Finder extends Base
      */
     public function process()
     {
-        $this->getQuery()->find($this->finder(), (array)$this->getArgs());
+        $args = (array)$this->getArgs();
+        $map = $this->getConfig('map');
+        foreach ($map as $from => $to) {
+            $args[$to] = isset($args[$from]) ? $args[$from] : null;
+        }
+
+        $this->getQuery()->find($this->finder(), $args);
 
         return true;
     }

--- a/src/Model/Filter/Finder.php
+++ b/src/Model/Filter/Finder.php
@@ -31,7 +31,7 @@ class Finder extends Base
     {
         $args = (array)$this->getArgs();
         $map = $this->getConfig('map');
-        foreach ($map as $from => $to) {
+        foreach ($map as $to => $from) {
             $args[$to] = isset($args[$from]) ? $args[$from] : null;
         }
 

--- a/tests/TestApp/Model/Table/FinderArticlesTable.php
+++ b/tests/TestApp/Model/Table/FinderArticlesTable.php
@@ -9,6 +9,10 @@ use Cake\ORM\Table;
  */
 class FinderArticlesTable extends Table
 {
+    /**
+     * @param array $config
+     * @return void
+     */
     public function initialize(array $config)
     {
         parent::initialize($config);
@@ -16,10 +20,29 @@ class FinderArticlesTable extends Table
         $this->table('articles');
     }
 
+    /**
+     * @param \Cake\ORM\Query $query
+     * @param array $options
+     *
+     * @return \Cake\ORM\Query
+     */
     public function findActive(Query $query, array $options)
     {
         return $query->where([
                 'Articles.is_active' => true
             ] + $options['active']);
+    }
+
+    /**
+     * Requires slug key to be present
+     *
+     * @param \Cake\ORM\Query $query
+     * @param array $options
+     *
+     * @return \Cake\ORM\Query
+     */
+    public function findSlugged(Query $query, array $options)
+    {
+        return $query->where(['title' => $options['slug']]);
     }
 }

--- a/tests/TestApp/Model/Table/FinderArticlesTable.php
+++ b/tests/TestApp/Model/Table/FinderArticlesTable.php
@@ -34,7 +34,7 @@ class FinderArticlesTable extends Table
     }
 
     /**
-     * Requires slug key to be present
+     * Requires slug key to be present in $options array.
      *
      * @param \Cake\ORM\Query $query
      * @param array $options

--- a/tests/TestCase/Model/Filter/FinderTest.php
+++ b/tests/TestCase/Model/Filter/FinderTest.php
@@ -45,6 +45,7 @@ class FinderTest extends TestCase
 
     /**
      * Tests that a custom finder that requires certain keys can be used through map functionality.
+     * Here we map the posted field key "form_slug" to "slug" key of the finder.
      *
      * @return void
      */
@@ -54,8 +55,8 @@ class FinderTest extends TestCase
             'className' => '\Search\Test\TestApp\Model\Table\FinderArticlesTable'
         ]);
         $manager = new Manager($articles);
-        $filter = new Finder('slugged', $manager, ['map' => ['title' => 'slug']]);
-        $filter->setArgs(['title' => 'foo']);
+        $filter = new Finder('slugged', $manager, ['map' => ['slug' => 'form_slug']]);
+        $filter->setArgs(['form_slug' => 'foo']);
         $filter->setQuery($articles->find());
         $filter->process();
 

--- a/tests/TestCase/Model/Filter/FinderTest.php
+++ b/tests/TestCase/Model/Filter/FinderTest.php
@@ -44,6 +44,32 @@ class FinderTest extends TestCase
     }
 
     /**
+     * Tests that a custom finder that requires certain keys can be used through map functionality.
+     *
+     * @return void
+     */
+    public function testProcessMap()
+    {
+        $articles = TableRegistry::get('FinderArticles', [
+            'className' => '\Search\Test\TestApp\Model\Table\FinderArticlesTable'
+        ]);
+        $manager = new Manager($articles);
+        $filter = new Finder('slugged', $manager, ['map' => ['title' => 'slug']]);
+        $filter->setArgs(['title' => 'foo']);
+        $filter->setQuery($articles->find());
+        $filter->process();
+
+        $this->assertRegExp(
+            '/WHERE title = :c0$/',
+            $filter->getQuery()->sql()
+        );
+        $this->assertEquals(
+            ['foo'],
+            Hash::extract($filter->getQuery()->valueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
      * @expectedException \BadMethodCallException
      * @expectedExceptionMessage Unknown finder method "nonExistent"
      * @return void


### PR DESCRIPTION
Almost always custom finders require certain keys to be present. And you cannot change that, especially not for plugin finders.

Make custom finders get the right fields via map functionality.

Refs https://github.com/dereuromark/cakephp-tools/pull/200 which needs this functionality.