### PR TITLE
Cleanup

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,5 +2,4 @@ parameters:
     autoload_files:
         - tests/bootstrap.php
     ignoreErrors:
-        - '#Call to an undefined method Cake\\Datasource\\RepositoryInterface::aliasField\(\)#'
         - '#Call to an undefined method Cake\\ORM\\Table::searchManager\(\)#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,4 +2,5 @@ parameters:
     autoload_files:
         - tests/bootstrap.php
     ignoreErrors:
+        - '#Call to an undefined method Cake\\Datasource\\RepositoryInterface::aliasField\(\)#'
         - '#Call to an undefined method Cake\\ORM\\Table::searchManager\(\)#'

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -3,7 +3,6 @@ namespace Search\Model\Filter;
 
 use Cake\Core\InstanceConfigTrait;
 use Cake\Datasource\QueryInterface;
-use Cake\ORM\Table;
 use Search\Manager;
 
 /**
@@ -112,7 +111,7 @@ abstract class Base implements FilterInterface
         }
 
         $repository = $this->manager()->getRepository();
-        if (!$repository instanceof Table) {
+        if (!method_exists($repository, 'aliasField')) {
             return $field;
         }
 

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -3,6 +3,7 @@ namespace Search\Model\Filter;
 
 use Cake\Core\InstanceConfigTrait;
 use Cake\Datasource\QueryInterface;
+use Cake\ORM\Table;
 use Search\Manager;
 
 /**
@@ -111,7 +112,7 @@ abstract class Base implements FilterInterface
         }
 
         $repository = $this->manager()->getRepository();
-        if (!method_exists($repository, 'aliasField')) {
+        if (!$repository instanceof Table) {
             return $field;
         }
 

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -260,12 +260,12 @@ abstract class Base implements FilterInterface
     /**
      * Sets the query object.
      *
-     * @param \Cake\Datasource\QueryInterface $value Value.
+     * @param \Cake\Datasource\QueryInterface $query Query instance.
      * @return void
      */
-    public function setQuery(QueryInterface $value)
+    public function setQuery(QueryInterface $query)
     {
-        $this->_query = $value;
+        $this->_query = $query;
     }
 
     /**

--- a/src/Model/Filter/FilterInterface.php
+++ b/src/Model/Filter/FilterInterface.php
@@ -69,10 +69,10 @@ interface FilterInterface
     /**
      * Sets the query object.
      *
-     * @param \Cake\Datasource\QueryInterface $value Value.
+     * @param \Cake\Datasource\QueryInterface $query Query instance.
      * @return void
      */
-    public function setQuery(QueryInterface $value);
+    public function setQuery(QueryInterface $query);
 
     /**
      * Gets the query object.

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -2,7 +2,10 @@
 namespace Search\Model\Filter;
 
 use Cake\Core\App;
+use Cake\ORM\Query;
+use Cake\ORM\Table;
 use InvalidArgumentException;
+use RuntimeException;
 use Search\Manager;
 
 class Like extends Base
@@ -88,7 +91,7 @@ class Like extends Base
     protected function _aliasColTypes($colTypes)
     {
         $repository = $this->manager()->getRepository();
-        if (!method_exists($repository, 'aliasField')) {
+        if (!$repository instanceof Table) {
             return $colTypes;
         }
 
@@ -147,8 +150,10 @@ class Like extends Base
     protected function _setEscaper()
     {
         if ($this->getConfig('escaper') === null) {
-            /** @var \Cake\Database\Query $query */
             $query = $this->getQuery();
+            if (!$query instanceof Query) {
+                throw new RuntimeException('$query must be instance of Cake\ORM\Query to be able to check driver name.');
+            }
             $driver = get_class($query->getConnection()->getDriver());
             $driverName = 'Sqlserver';
             if (substr_compare($driver, $driverName, -strlen($driverName)) === 0) {

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -3,10 +3,8 @@ namespace Search\Model\Filter;
 
 use Cake\Core\App;
 use Cake\ORM\Query;
-use Cake\ORM\Table;
 use InvalidArgumentException;
 use RuntimeException;
-use Search\Manager;
 
 class Like extends Base
 {
@@ -91,7 +89,7 @@ class Like extends Base
     protected function _aliasColTypes($colTypes)
     {
         $repository = $this->manager()->getRepository();
-        if (!$repository instanceof Table) {
+        if (!method_exists($repository, 'aliasField')) {
             return $colTypes;
         }
 

--- a/tests/TestCase/Model/SearchTraitTest.php
+++ b/tests/TestCase/Model/SearchTraitTest.php
@@ -65,8 +65,8 @@ class SearchTraitTest extends TestCase
 
         $query = $this->Articles->find('search', ['search' => $queryString]);
         $this->assertSame([
-            'foo' => 'a',
-            'public' => false,
+            'Articles.foo' => 'a',
+            'Articles.public' => false,
         ], $query->where());
         $this->assertTrue($this->Articles->isSearch());
     }

--- a/tests/TestCase/Model/SearchTraitTest.php
+++ b/tests/TestCase/Model/SearchTraitTest.php
@@ -3,16 +3,18 @@
 namespace Search\Test\TestCase\Model;
 
 use Cake\TestSuite\TestCase;
+use Muffin\Webservice\AbstractDriver;
 use Muffin\Webservice\Connection;
+use Muffin\Webservice\Webservice\Webservice;
 use Search\Manager;
 use Search\Test\TestApp\Model\Endpoint\ArticlesEndpoint;
 
 class SearchTraitTest extends TestCase
 {
     /**
-     * @var \Search\Test\TestApp\Model\Table\ArticlesTable
+     * @var \Search\Test\TestApp\Model\Endpoint\ArticlesEndpoint
      */
-    public $Articles;
+    protected $Articles;
 
     /**
      * setup
@@ -23,13 +25,13 @@ class SearchTraitTest extends TestCase
     {
         parent::setUp();
 
-        $webserviceMock = $this->getMockBuilder('\Muffin\Webservice\Webservice\Webservice')
+        $webserviceMock = $this->getMockBuilder(Webservice::class)
             ->getMock();
 
-        $driverMock = $this->getMockBuilder('\Muffin\Webservice\AbstractDriver')
+        $driverMock = $this->getMockBuilder(AbstractDriver::class)
             ->getMockForAbstractClass();
 
-        $connectionMock = $this->getMockBuilder('\Muffin\Webservice\Connection')
+        $connectionMock = $this->getMockBuilder(Connection::class)
             ->setConstructorArgs([
                 [
                     'name' => 'test',
@@ -63,8 +65,8 @@ class SearchTraitTest extends TestCase
 
         $query = $this->Articles->find('search', ['search' => $queryString]);
         $this->assertSame([
-            'Articles.foo' => 'a',
-            'Articles.public' => false,
+            'foo' => 'a',
+            'public' => false,
         ], $query->where());
         $this->assertTrue($this->Articles->isSearch());
     }
@@ -89,6 +91,6 @@ class SearchTraitTest extends TestCase
     public function testSearchManager()
     {
         $manager = $this->Articles->searchManager();
-        $this->assertInstanceOf('\Search\Manager', $manager);
+        $this->assertInstanceOf(Manager::class, $manager);
     }
 }


### PR DESCRIPTION
@dereuromark While working on this I realized we have the same issue with use of typhint `Cake\Datasource\RepositoryInterface` as we have with `Cake\Datasource\QueryInterface`. The filters have code like `$repository->aliasField()` but the `aliasField()` method is not there in `RepositoryInterface`.

Adding `instanceof` checks makes phpstan happy and we don't need to ignore any errors or override variable types inline. So I think this is enough and we don't need to make any changes to the typehints. We can revisit them when we work on Cake 4 compatible version of the plugin, where hopefully the interfaces will be fixed up :slightly_smiling_face:.