### PR TITLE
Lazy load filter collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,39 @@ Let's use the *backend*'s filters by doing:
     }
 ```
 
+Apart from creating filter collections through search mananger in your table
+class, you can also create them as separate collection classes.
+
+```php
+// src/Model/Filter/MyPostsCollection.php
+namespace App\Model\Files\MyPostsCollection;
+
+use Search\Model\Filter\FilterCollection;
+
+class MyPostsCollection extends FilterCollection
+{
+    public function initialize()
+    {
+        $this->add('foo', 'Search.Callback', [
+            'callback' => function ($query, $args, $filter) {
+                // Modify $query as required
+            }
+        ]);
+        // More $this->add() calls here. The argument for FilterCollection::add()
+        // are same as those of searchManager()->add() shown above.
+    }
+}
+```
+
+To use this `MyPosts` collection just specify the collection name in underscored
+form in `find()` call.
+
+```php
+$query = $this->Examples->find('search', [
+    'search' => $this->request->getQuery(), 'collection' => 'my_posts'
+]);
+```
+
 ## Optional fields
 
 Sometimes you might want to search your data based on two of three inputs in

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -1,7 +1,9 @@
 <?php
 namespace Search;
 
+use Cake\Core\App;
 use Cake\Datasource\RepositoryInterface;
+use Cake\Utility\Inflector;
 use InvalidArgumentException;
 use Search\Model\Filter\FilterCollection;
 use Search\Model\Filter\FilterCollectionInterface;
@@ -87,9 +89,7 @@ class Manager
     public function getFilters($collection = 'default')
     {
         if (!isset($this->_collections[$collection])) {
-            throw new InvalidArgumentException(
-                sprintf('The collection "%s" does not exist.', $collection)
-            );
+            $this->_collections[$collection] = $this->_loadCollection($collection);
         }
 
         if ($this->_collections[$collection] instanceof FilterCollectionInterface) {
@@ -97,6 +97,28 @@ class Manager
         }
 
         return $this->_collections[$collection];
+    }
+
+    /**
+     * Loads a filter collection.
+     *
+     * @param string $name Collection name.
+     * @return \Search\Model\Filter\FilterCollectionInterface
+     * @throws \InvalidArgumentException When no filter was found.
+     */
+    protected function _loadCollection($name)
+    {
+        $class = Inflector::camelize($name);
+
+        $className = App::className($class, 'Model/Filter', 'Collection');
+        if (!$className) {
+            throw new InvalidArgumentException(sprintf(
+                'The collection class "%sCollection" does not exist',
+                $class
+            ));
+        }
+
+        return new $className($this->_filterLocator);
     }
 
     /**

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -26,7 +26,7 @@ class Manager
     /**
      * Filter collections
      *
-     * @var Search\Model\Filter\FilterCollectionInterface[] Filter collections list.
+     * @var \Search\Model\Filter\FilterCollectionInterface[] Filter collections list.
      */
     protected $_collections = [];
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -53,7 +53,7 @@ class Manager
     {
         $this->_repository = $repository;
         $this->_filterLocator = new FilterLocator($this);
-        $this->_filters['default'] = new FilterCollection();
+        $this->_filters['default'] = new FilterCollection($this->_filterLocator);
     }
 
     /**
@@ -110,7 +110,7 @@ class Manager
     public function useCollection($name)
     {
         if (!isset($this->_filters[$name])) {
-            $this->_filters[$name] = [];
+            $this->_filters[$name] = new FilterCollection($this->_filterLocator);
         }
         $this->_collection = $name;
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -22,13 +22,11 @@ class Manager
     protected $_repository;
 
     /**
-     * Filter collection and their filters
+     * Filter collections
      *
-     * @var array
+     * @var Search\Model\Filter\FilterCollectionInterface[] Filter collections list.
      */
-    protected $_filters = [
-        'default' => []
-    ];
+    protected $_collections = [];
 
     /**
      * Active filter collection.
@@ -53,7 +51,7 @@ class Manager
     {
         $this->_repository = $repository;
         $this->_filterLocator = new FilterLocator($this);
-        $this->_filters['default'] = new FilterCollection($this->_filterLocator);
+        $this->_collections['default'] = new FilterCollection($this->_filterLocator);
     }
 
     /**
@@ -88,17 +86,17 @@ class Manager
      */
     public function getFilters($collection = 'default')
     {
-        if (!isset($this->_filters[$collection])) {
+        if (!isset($this->_collections[$collection])) {
             throw new InvalidArgumentException(
                 sprintf('The collection "%s" does not exist.', $collection)
             );
         }
 
-        if ($this->_filters[$collection] instanceof FilterCollectionInterface) {
-            return $this->_filters[$collection]->toArray();
+        if ($this->_collections[$collection] instanceof FilterCollectionInterface) {
+            return $this->_collections[$collection]->toArray();
         }
 
-        return $this->_filters[$collection];
+        return $this->_collections[$collection];
     }
 
     /**
@@ -109,8 +107,8 @@ class Manager
      */
     public function useCollection($name)
     {
-        if (!isset($this->_filters[$name])) {
-            $this->_filters[$name] = new FilterCollection($this->_filterLocator);
+        if (!isset($this->_collections[$name])) {
+            $this->_collections[$name] = new FilterCollection($this->_filterLocator);
         }
         $this->_collection = $name;
 
@@ -137,7 +135,7 @@ class Manager
      */
     public function add($name, $filter, array $options = [])
     {
-        $this->_filters[$this->_collection][$name] = $this->loadFilter($name, $filter, $options);
+        $this->_collections[$this->_collection]->add($name, $filter, $options);
 
         return $this;
     }
@@ -150,7 +148,7 @@ class Manager
      */
     public function remove($name)
     {
-        unset($this->_filters[$this->_collection][$name]);
+        unset($this->_collections[$this->_collection][$name]);
     }
 
     /**
@@ -249,20 +247,6 @@ class Manager
         $this->add($name, $config['className'], $config);
 
         return $this;
-    }
-
-    /**
-     * Loads a search filter.
-     *
-     * @param string $name Name of the field
-     * @param string $filter Filter name
-     * @param array $options Filter options.
-     * @return \Search\Model\Filter\Base
-     * @throws \InvalidArgumentException When no filter was found.
-     */
-    public function loadFilter($name, $filter, array $options = [])
-    {
-        return $this->_filterLocator->get($name, $filter, $options);
     }
 
     /**

--- a/src/Model/Filter/FilterCollection.php
+++ b/src/Model/Filter/FilterCollection.php
@@ -41,7 +41,7 @@ class FilterCollection implements FilterCollectionInterface
      */
     public function add($name, $filter, array $options = [])
     {
-        $this->_filters[$name] = $this->getFilter($name, $filter, $options);
+        $this->_filters[$name] = $this->loadFilter($name, $filter, $options);
 
         return $this;
     }
@@ -55,7 +55,7 @@ class FilterCollection implements FilterCollectionInterface
      * @return \Search\Model\Filter\FilterInterface
      * @throws \InvalidArgumentException When no filter was found.
      */
-    public function getFilter($name, $filter, array $options = [])
+    public function loadFilter($name, $filter, array $options = [])
     {
         return $this->_filterLocator->get($name, $filter, $options);
     }

--- a/src/Model/Filter/FilterCollection.php
+++ b/src/Model/Filter/FilterCollection.php
@@ -2,6 +2,7 @@
 namespace Search\Model\Filter;
 
 use ArrayIterator;
+use Search\Model\Filter\FilterLocatorInterface;
 
 /**
  * FilterCollection
@@ -14,16 +15,49 @@ class FilterCollection implements FilterCollectionInterface
     protected $filters = [];
 
     /**
-     * Adds a filter
+     * Filter Locator
      *
-     * @param \Search\Model\Filter\FilterInterface $filter Filter
+     * @var \Search\Model\Filter\FilterLocatorInterface
+     */
+    protected $_filterLocator;
+
+    /**
+     * Constructor
+     *
+     * @param \Search\Model\Filter\FilterLocatorInterface $locator Filter locator
+     */
+    public function __construct(FilterLocatorInterface $locator)
+    {
+        $this->_filterLocator = $locator;
+    }
+
+    /**
+     * Adds filter to the collection.
+     *
+     * @param string $name Filter name.
+     * @param string $filter Filter class name in short form like "Search.Value" or FQCN.
+     * @param array $options Filter options.
      * @return $this
      */
-    public function add(FilterInterface $filter)
+    public function add($name, $filter, array $options = [])
     {
-        $this->filters[$filter->name()] = $filter;
+        $this->filters[$name] = $this->getFilter($name, $filter, $options);
 
         return $this;
+    }
+
+    /**
+     * Loads a search filter.
+     *
+     * @param string $name Filter name.
+     * @param string $filter Filter class name in short form like "Search.Value" or FQCN.
+     * @param array $options Filter options.
+     * @return \Search\Model\Filter\FilterInterface
+     * @throws \InvalidArgumentException When no filter was found.
+     */
+    public function getFilter($name, $filter, array $options = [])
+    {
+        return $this->_filterLocator->get($name, $filter, $options);
     }
 
     /**

--- a/src/Model/Filter/FilterCollection.php
+++ b/src/Model/Filter/FilterCollection.php
@@ -29,6 +29,17 @@ class FilterCollection implements FilterCollectionInterface
     public function __construct(FilterLocatorInterface $locator)
     {
         $this->_filterLocator = $locator;
+
+        $this->initialize();
+    }
+
+    /**
+     * Initialize method.
+     *
+     * @return void
+     */
+    public function initialize()
+    {
     }
 
     /**

--- a/src/Model/Filter/FilterCollection.php
+++ b/src/Model/Filter/FilterCollection.php
@@ -12,7 +12,7 @@ class FilterCollection implements FilterCollectionInterface
     /**
      * @var array List of filter objects
      */
-    protected $filters = [];
+    protected $_filters = [];
 
     /**
      * Filter Locator
@@ -41,7 +41,7 @@ class FilterCollection implements FilterCollectionInterface
      */
     public function add($name, $filter, array $options = [])
     {
-        $this->filters[$name] = $this->getFilter($name, $filter, $options);
+        $this->_filters[$name] = $this->getFilter($name, $filter, $options);
 
         return $this;
     }
@@ -72,7 +72,7 @@ class FilterCollection implements FilterCollectionInterface
             $name = $name->name();
         }
 
-        return isset($this->filters[$name]);
+        return isset($this->_filters[$name]);
     }
 
     /**
@@ -83,7 +83,7 @@ class FilterCollection implements FilterCollectionInterface
      */
     public function remove($name)
     {
-        unset($this->filters[$name]);
+        unset($this->_filters[$name]);
 
         return $this;
     }
@@ -95,7 +95,7 @@ class FilterCollection implements FilterCollectionInterface
      */
     public function getIterator()
     {
-        return new ArrayIterator($this->filters);
+        return new ArrayIterator($this->_filters);
     }
 
     /**
@@ -120,7 +120,7 @@ class FilterCollection implements FilterCollectionInterface
     public function offsetGet($offset)
     {
         if ($this->has($offset)) {
-            return $this->filters[$offset];
+            return $this->_filters[$offset];
         }
 
         return null;
@@ -136,7 +136,7 @@ class FilterCollection implements FilterCollectionInterface
      */
     public function offsetSet($offset, $value)
     {
-        $this->filters[$offset] = $value;
+        $this->_filters[$offset] = $value;
     }
 
     /**
@@ -159,6 +159,6 @@ class FilterCollection implements FilterCollectionInterface
      */
     public function toArray()
     {
-        return $this->filters;
+        return $this->_filters;
     }
 }

--- a/src/Model/Filter/FilterCollectionInterface.php
+++ b/src/Model/Filter/FilterCollectionInterface.php
@@ -10,12 +10,14 @@ use IteratorAggregate;
 interface FilterCollectionInterface extends IteratorAggregate, ArrayAccess
 {
     /**
-     * Adds a filter
+     * Adds filter to the collection.
      *
-     * @param  \Search\Model\Filter\FilterInterface $filter Filter
+     * @param string $name Filter name.
+     * @param string $filter Filter class name in short form like "Search.Value" or FQCN.
+     * @param array $options Filter options.
      * @return $this
      */
-    public function add(FilterInterface $filter);
+    public function add($name, $filter, array $options = []);
 
     /**
      * Removes a filter by name

--- a/tests/TestApp/Model/Filter/MyTestCollection.php
+++ b/tests/TestApp/Model/Filter/MyTestCollection.php
@@ -1,0 +1,13 @@
+<?php
+namespace Search\Test\TestApp\Model\Filter;
+
+use Search\Model\Filter\FilterCollection;
+
+class MyTestCollection extends FilterCollection
+{
+
+    public function initialize()
+    {
+        $this->add('first', 'Search.Callback');
+    }
+}

--- a/tests/TestCase/ManagerTest.php
+++ b/tests/TestCase/ManagerTest.php
@@ -130,18 +130,23 @@ class ManagerTest extends TestCase
         $this->assertCount(2, $result);
         $this->assertInstanceOf('\Search\Model\Filter\Value', $result['test']);
         $this->assertInstanceOf('\Search\Model\Filter\Compare', $result['test2']);
+
+        Configure::write('App.namespace', 'Search\Test\TestApp');
+        $result = $manager->getFilters('my_test');
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf('\Search\Model\Filter\Callback', $result['first']);
     }
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The collection "nonExistentCollection" does not exist.
+     * @expectedExceptionMessage The collection class "NonExistentCollection" does not exist
      * @return void
      */
     public function testGetFiltersNonExistentCollection()
     {
         $table = TableRegistry::get('Articles');
         $manager = new Manager($table);
-        $manager->getFilters('nonExistentCollection');
+        $manager->getFilters('non_existent');
     }
 
     /**

--- a/tests/TestCase/ManagerTest.php
+++ b/tests/TestCase/ManagerTest.php
@@ -103,21 +103,6 @@ class ManagerTest extends TestCase
     /**
      * @return void
      */
-    public function testLoadFilter()
-    {
-        $table = TableRegistry::get('Articles');
-        $manager = new Manager($table);
-
-        $result = $manager->loadFilter('test', 'Search.Value');
-        $this->assertInstanceOf('\Search\Model\Filter\Value', $result);
-
-        $result = $manager->loadFilter('test', 'Search.Compare');
-        $this->assertInstanceOf('\Search\Model\Filter\Compare', $result);
-    }
-
-    /**
-     * @return void
-     */
     public function testAdd()
     {
         $table = TableRegistry::get('Articles');
@@ -129,17 +114,6 @@ class ManagerTest extends TestCase
         $this->assertCount(2, $result);
         $this->assertInstanceOf('\Search\Model\Filter\Value', $result['testOne']);
         $this->assertInstanceOf('\Search\Model\Filter\Compare', $result['testTwo']);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     * @return void
-     */
-    public function testLoadFilterInvalidArgumentException()
-    {
-        $table = TableRegistry::get('Articles');
-        $manager = new Manager($table);
-        $manager->loadFilter('test', 'DOES-NOT-EXIST');
     }
 
     /**

--- a/tests/TestCase/Model/Filter/FilterCollectionTest.php
+++ b/tests/TestCase/Model/Filter/FilterCollectionTest.php
@@ -5,29 +5,59 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Search\Manager;
 use Search\Model\Filter\Callback;
+use Search\Model\Filter\Compare;
 use Search\Model\Filter\FilterCollection;
 use Search\Model\Filter\FilterCollectionInterface;
 use Search\Model\Filter\FilterLocator;
+use Search\Model\Filter\Value;
 
 /**
  * Filter Collection Test
  */
 class FilterCollectionTest extends TestCase
 {
-    public function testCollection()
+    public function setUp()
     {
         $repository = TableRegistry::get('Articles');
         $manager = new Manager($repository);
 
-        $collection = new FilterCollection(new FilterLocator($manager));
-        $result = $collection->add('test', 'Search.Callback');
+        $this->collection = new FilterCollection(new FilterLocator($manager));
+    }
+
+    public function testCollection()
+    {
+        $result = $this->collection->add('test', 'Search.Callback');
         $this->assertInstanceOf(FilterCollectionInterface::class, $result);
 
-        $this->assertTrue($collection->has('test'));
-        $this->assertFalse($collection->has('doesNotExist'));
+        $this->assertTrue($this->collection->has('test'));
+        $this->assertFalse($this->collection->has('doesNotExist'));
 
-        $result = $collection->remove('test');
+        $result = $this->collection->remove('test');
         $this->assertInstanceOf(FilterCollectionInterface::class, $result);
-        $this->assertFalse($collection->has('test'));
+        $this->assertFalse($this->collection->has('test'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetFilter()
+    {
+        $result = $this->collection->loadFilter('test', 'Search.Value');
+        $this->assertInstanceOf(Value::class, $result);
+
+        $result = $this->collection->loadFilter('test', 'Search.Compare');
+        $this->assertInstanceOf(Compare::class, $result);
+    }
+
+    /**
+     * testLoadFilterInvalidArgumentException()
+     *
+     * @return void
+     */
+    public function testLoadFilterInvalidArgumentException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->collection->loadFilter('test', 'DOES-NOT-EXIST');
     }
 }

--- a/tests/TestCase/Model/Filter/FilterCollectionTest.php
+++ b/tests/TestCase/Model/Filter/FilterCollectionTest.php
@@ -7,6 +7,7 @@ use Search\Manager;
 use Search\Model\Filter\Callback;
 use Search\Model\Filter\FilterCollection;
 use Search\Model\Filter\FilterCollectionInterface;
+use Search\Model\Filter\FilterLocator;
 
 /**
  * Filter Collection Test
@@ -17,13 +18,11 @@ class FilterCollectionTest extends TestCase
     {
         $repository = TableRegistry::get('Articles');
         $manager = new Manager($repository);
-        $filter = new Callback('test', $manager);
 
-        $collection = new FilterCollection();
-        $result = $collection->add($filter);
+        $collection = new FilterCollection(new FilterLocator($manager));
+        $result = $collection->add('test', 'Search.Callback');
         $this->assertInstanceOf(FilterCollectionInterface::class, $result);
 
-        $this->assertTrue($collection->has($filter));
         $this->assertTrue($collection->has('test'));
         $this->assertFalse($collection->has('doesNotExist'));
 


### PR DESCRIPTION
This achieves the lazy loading of filter collection that I had stated in https://github.com/FriendsOfCake/search/issues/224#issuecomment-392764849.

- You can now have filter collection in your app e.g. `App\Model\Filter\MySweetCollection.php`.
  Use the `FilterCollection::initialize()` method to setup filters using `FilterCollection::add()`.
- Add search behavior to your table, no need to use search manager to setup filters.
- Specify the collection name in find call e.g. 
  `find('search', ['collection' => 'my_sweet', 'search' => $queryParams])`
  and viola!.

P.S. Search manager no longer loads filters directly anymore, nor does it maintain array of filters arrays. It only has array of collections now and filter loading is always delegated to the collection.