### PR TITLE
Add multi value separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,10 @@ The following options are supported by all filters except `Callback` and `Finder
   multiple values. If disabled, and multiple values are being passed, the filter
   will fall back to using the default value defined by the `defaultValue` option.
 
+- `multiValueSeparator` (`string`, defaults to `null`) Defines whether the filter should
+  auto-tokenize multiple values using a specific separator string. If disabled, the data
+  must be an in form of an array.
+
 - `field` (`string|array`), defaults to the name passed to the first argument of the
   add filter method) The name of the field to use for searching. Works like the base
   `field` option but also accepts multiple field names as an array. When defining
@@ -389,6 +393,10 @@ The following options are supported by all filters except `Callback` and `Finder
 - `multiValue` (`bool`, defaults to `false`) Defines whether the filter accepts
   multiple values. If disabled, and multiple values are being passed, the filter
   will fall back to using the default value defined by the `defaultValue` option.
+  
+- `multiValueSeparator` (`string`, defaults to `null`) Defines whether the filter should
+  auto-tokenize multiple values using a specific separator string. If disabled, the data
+  must be an in form of an array.  
 
 - `mode` (`string`, defaults to `OR`) The conditional mode to use when matching
   against multiple fields. Valid values are `OR` and `AND`.

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -214,7 +214,7 @@ abstract class Base
             return $this->getConfig('multiValue') ? $value : null;
         }
 
-        if ($this->getConfig('multiValue') && $this->getConfig('multiValueSeparator')) {
+        if ($this->getConfig('multiValueSeparator')) {
             return explode($this->getConfig('multiValueSeparator'), $value);
         }
 

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -196,12 +196,6 @@ abstract class Base
             return $value;
         }
 
-        if (!is_array($passedValue) ||
-            $this->getConfig('multiValue')
-        ) {
-            return $passedValue;
-        }
-
         return $value;
     }
 
@@ -215,6 +209,10 @@ abstract class Base
         }
 
         $value = $this->_args[$this->name()];
+
+        if (is_array($value)) {
+            return $this->getConfig('multiValue') ? $value : null;
+        }
 
         if ($this->getConfig('multiValueSeparator')) {
             return explode($this->getConfig('multiValueSeparator'), $value);

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -196,7 +196,7 @@ abstract class Base
             return $value;
         }
 
-        return $value;
+        return $passedValue;
     }
 
     /**
@@ -214,7 +214,7 @@ abstract class Base
             return $this->getConfig('multiValue') ? $value : null;
         }
 
-        if ($this->getConfig('multiValueSeparator')) {
+        if ($this->getConfig('multiValue') && $this->getConfig('multiValueSeparator')) {
             return explode($this->getConfig('multiValueSeparator'), $value);
         }
 

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -208,7 +208,7 @@ abstract class Base
     /**
      * @return string|array|null
      */
-    public function passedValue()
+    protected function passedValue()
     {
         if (!isset($this->_args[$this->name()])) {
             return null;

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -51,6 +51,7 @@ abstract class Base
      * @param string $name Name.
      * @param \Search\Manager $manager Manager.
      * @param array $config Config.
+     * @throws \InvalidArgumentException
      */
     public function __construct($name, Manager $manager, array $config = [])
     {
@@ -65,6 +66,7 @@ abstract class Base
             'filterEmpty' => false,
             'defaultValue' => null,
             'multiValue' => false,
+            'multiValueSeparator' => null,
             'flatten' => true,
         ];
         $config += $defaults;
@@ -188,13 +190,34 @@ abstract class Base
     public function value()
     {
         $value = $this->_config['defaultValue'];
-        if (isset($this->_args[$this->name()])) {
-            $passedValue = $this->_args[$this->name()];
-            if (!is_array($passedValue) ||
-                $this->getConfig('multiValue')
-            ) {
-                return $passedValue;
-            }
+
+        $passedValue = $this->passedValue();
+        if ($passedValue === null) {
+            return $value;
+        }
+
+        if (!is_array($passedValue) ||
+            $this->getConfig('multiValue')
+        ) {
+            return $passedValue;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return string|array|null
+     */
+    public function passedValue()
+    {
+        if (!isset($this->_args[$this->name()])) {
+            return null;
+        }
+
+        $value = $this->_args[$this->name()];
+
+        if ($this->getConfig('multiValueSeparator')) {
+            return explode($this->getConfig('multiValueSeparator'), $value);
         }
 
         return $value;

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -143,6 +143,7 @@ class Like extends Base
      * set configuration for escape driver name
      *
      * @return void
+     * @throws \InvalidArgumentException
      */
     protected function _setEscaper()
     {

--- a/tests/TestCase/Model/Filter/BaseTest.php
+++ b/tests/TestCase/Model/Filter/BaseTest.php
@@ -201,14 +201,27 @@ class BaseTest extends TestCase
             ['defaultValue' => 'default']
         );
 
-        $filter->setConfig('multiValue', true);
         $filter->setConfig('multiValueSeparator', '|');
 
         $filter->setArgs(['field' => 'value1|value2']);
         $this->assertEquals(['value1', 'value2'], $filter->value());
+    }
 
-        $filter->setArgs(['field' => ['value1', 'value2']]);
-        $this->assertEquals(['value1', 'value2'], $filter->value());
+    /**
+     * @return void
+     */
+    public function testValueMultiValueSeparatorInvalid()
+    {
+        $filter = new TestFilter(
+            'field',
+            $this->Manager,
+            ['defaultValue' => 'default']
+        );
+
+        $filter->setConfig('multiValue', true);
+
+        $filter->setArgs(['field' => 'value1|value2']);
+        $this->assertEquals('value1|value2', $filter->value());
     }
 
     /**

--- a/tests/TestCase/Model/Filter/BaseTest.php
+++ b/tests/TestCase/Model/Filter/BaseTest.php
@@ -172,8 +172,41 @@ class BaseTest extends TestCase
 
         $filter->setArgs(['field' => ['value1', 'value2']]);
         $this->assertEquals('default', $filter->value());
+    }
+
+    /**
+     * @return void
+     */
+    public function testValueMultiValue()
+    {
+        $filter = new TestFilter(
+            'field',
+            $this->Manager,
+            ['defaultValue' => 'default']
+        );
 
         $filter->setConfig('multiValue', true);
+        $filter->setArgs(['field' => ['value1', 'value2']]);
+        $this->assertEquals(['value1', 'value2'], $filter->value());
+    }
+
+    /**
+     * @return void
+     */
+    public function testValueMultiValueSeparator()
+    {
+        $filter = new TestFilter(
+            'field',
+            $this->Manager,
+            ['defaultValue' => 'default']
+        );
+
+        $filter->setConfig('multiValue', true);
+        $filter->setConfig('multiValueSeparator', '|');
+
+        $filter->setArgs(['field' => 'value1|value2']);
+        $this->assertEquals(['value1', 'value2'], $filter->value());
+
         $filter->setArgs(['field' => ['value1', 'value2']]);
         $this->assertEquals(['value1', 'value2'], $filter->value());
     }


### PR DESCRIPTION
We need the multiValue func for a field:
```php
        $searchManager
            ->like('search', ['field' => ['name', 'issue'], 'multiValue' => true]);
```

Currently in each controller action for this we have to hack it a bit with this:
```php
        $searchQuery = $this->request->getQuery();
        if (!empty($searchQuery['search'])) {
            $searchQuery['search'] = explode('|', $searchQuery['search']);
        }
        $query = $this->ReleaseGroups->find('search', ['search' => $searchQuery]);
```

Not sure if this can be done differently, a bit cleaner.
But I think given the Base class could handle this easily, a multiValueSeparator would be a useful config addition:

```php
        $searchManager
            ->like('search', ['field' => ['name', 'issue'], 'multiValue' => true, 'multiValueSeparator' => '|']);
```

Allowing us to then DRY config this to be used in all such actions:
```
ps-1232|xyz-345|foobar-999
```

This should also work fine with wildcards etc.

If accepted I am happy to add tests here :)