### PR TITLE
Fix finder to allow setting options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ The following options are supported by all filters except `Callback` and `Finder
 #### `Finder`
 
 - `finder` (`string`) The [find type](https://book.cakephp.org/3.0/en/orm/retrieving-data-and-resultsets.html#custom-finder-methods) to use.
-  Use the `map` config array if you need to map your field to a finder key (`'to_field' => 'from_field'`).
+  Use the `map` config array if you need to map your field to a finder key (`'to_field' => 'from_field'`). Use `options` config to pass additional config.
 
 ## Filter collections
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,25 +6,24 @@
     >
 
     <testsuites>
-        <testsuite name="Slug Test Cases">
-            <directory>./tests/</directory>
+        <testsuite name="search">
+            <directory>tests/</directory>
         </testsuite>
     </testsuites>
 
     <!-- Setup a listener for fixtures -->
     <listeners>
         <listener
-        class="\Cake\TestSuite\Fixture\FixtureInjector"
-        file="./vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureInjector.php">
+        class="Cake\TestSuite\Fixture\FixtureInjector">
             <arguments>
-                <object class="\Cake\TestSuite\Fixture\FixtureManager" />
+                <object class="Cake\TestSuite\Fixture\FixtureManager" />
             </arguments>
         </listener>
     </listeners>
 
     <filter>
         <whitelist>
-            <directory suffix=".php">./src/</directory>
+            <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/src/Model/Filter/Finder.php
+++ b/src/Model/Filter/Finder.php
@@ -8,6 +8,7 @@ class Finder extends Base
      */
     protected $_defaultConfig = [
         'map' => [],
+        'options' => [],
     ];
 
     /**
@@ -34,6 +35,9 @@ class Finder extends Base
         foreach ($map as $to => $from) {
             $args[$to] = isset($args[$from]) ? $args[$from] : null;
         }
+
+        $options = $this->getConfig('options');
+        $args += $options;
 
         $this->getQuery()->find($this->finder(), $args);
 


### PR DESCRIPTION
I need an important small improvement/fix for finder config in search.

I was expecting this to work:
```php
        $searchManager
            ->finder('shop_type', ['finder' => 'bits', 'map' => ['bits' => 'shop_type'], 'type' => 'contain'])
            ...;
```
As the custom finder needs

    $this->find('bits', [..., 'type' => 'contain])

to work as expected.


Now at least this (own config to avoid noise) works:

```php
        $searchManager
            ->finder('shop_type', ['finder' => 'bits', 'map' => ['bits' => 'shop_type'], 'options' => ['type' => 'contain']])
```

updated docs.