### PR TITLE
Clarify MIT in license, add missing year.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright Friends of Cake
+The MIT License (MIT)
+
+Copyright 2015-present Friends of Cake
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This consolidates the license to the de facto standards

- filename
- including the word MIT in header for clarification
- include always valid year range

See e.g. https://github.com/spryker/code-generator/blob/master/LICENSE