### PR TITLE
Add Exists filter. 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,5 +15,4 @@ charset = utf-8
 end_of_line = crlf
 
 [*.yml]
-indent_style = space
 indent_size = 2

--- a/docs/README.md
+++ b/docs/README.md
@@ -283,6 +283,7 @@ easily create the search results you need. Use:
 - `Boolean` to limit results by truthy (by default: 1, true, '1', 'true', 'yes', 'on')
   and falsy (by default: 0, false, '0', 'false', 'no', 'off') values which are
   passed down to the ORM as true/1 or false/0 or ignored when being neither truthy or falsy.
+- `Exists` to produce results for existing (non-empty) column content.
 - `Finder` to produce results using a [(custom)](http://book.cakephp.org/3.0/en/orm/retrieving-data-and-resultsets.html#custom-find-methods) finder
 - `Compare` to produce results requiring operator comparison (`>`, `<`, `>=` and `<=`)
 - `Callback` to produce results using your own custom callable function, it
@@ -329,6 +330,13 @@ The following options are supported by all filters except `Callback` and `Finder
 
 - `mode` (`string`, defaults to `OR`) The conditional mode to use when matching
   against multiple fields. Valid values are `OR` and `AND`.
+  
+#### `Exists`
+
+- `mode` (`string`, defaults to `OR`) The conditional mode to use when matching
+  against multiple fields. Valid values are `OR` and `AND`.
+- `nullValue` (`string` or `null`, defaults to `null`). Can be used for non-nullable columns.
+Set it to an empty string there to check via `=`/`!=` instead of `IS NULL`/`IS NOT NULL`.
 
 #### `Compare`
 

--- a/src/Model/Filter/Boolean.php
+++ b/src/Model/Filter/Boolean.php
@@ -59,6 +59,6 @@ class Boolean extends Base
             $this->getQuery()->andWhere([$this->getConfig('mode') => $conditions]);
         }
 
-        return true;
+        return false;
     }
 }

--- a/src/Model/Filter/Compare.php
+++ b/src/Model/Filter/Compare.php
@@ -1,6 +1,8 @@
 <?php
 namespace Search\Model\Filter;
 
+use InvalidArgumentException;
+
 class Compare extends Base
 {
 
@@ -27,12 +29,13 @@ class Compare extends Base
      * Process a comparison-based condition (e.g. $field <= $value).
      *
      * @return bool
+     * @throws \InvalidArgumentException
      */
     public function process()
     {
         $conditions = [];
         if (!in_array($this->getConfig('operator'), $this->_operators, true)) {
-            throw new \InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'The operator %s is invalid!',
                 $this->getConfig('operator')
             ));

--- a/src/Model/Filter/Exists.php
+++ b/src/Model/Filter/Exists.php
@@ -1,0 +1,63 @@
+<?php
+namespace Search\Model\Filter;
+
+use Cake\ORM\Table;
+
+class Exists extends Base
+{
+    /**
+     * Default configuration.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'mode' => 'OR',
+        'nullValue' => null, // Set to empty string for required fields
+    ];
+
+    /**
+     * Check if a value is truthy/falsy and pass as condition aware of NULLable.
+     *
+     * @return bool
+     */
+    public function process()
+    {
+        $value = $this->value();
+        if (!is_scalar($value) || $value === '') {
+            return false;
+        }
+
+        $bool = (bool)$value;
+
+        $nullValue = $this->getConfig('nullValue');
+        $comparison = ' !=';
+        if (!$bool) {
+            $comparison = '';
+        }
+        if ($nullValue === null) {
+            $comparison = ' IS NOT';
+            if (!$bool) {
+                $comparison = ' IS';
+            }
+        }
+
+        if (!$this->manager()->getRepository() instanceof Table) {
+            foreach ($this->fields() as $field) {
+                $this->getQuery()->where([
+                    $field . $comparison => $nullValue,
+                ]);
+            }
+
+            return true;
+        }
+
+        $conditions = [];
+        foreach ($this->fields() as $field) {
+            $conditions[] = [$field . $comparison => $nullValue];
+        }
+
+        $this->getQuery()->andWhere([$this->getConfig('mode') => $conditions]);
+
+        return true;
+    }
+}

--- a/src/Model/Filter/FilterCollection.php
+++ b/src/Model/Filter/FilterCollection.php
@@ -74,7 +74,7 @@ class FilterCollection implements FilterCollectionInterface
     protected function _loadFilter($name, $filter, array $options = [])
     {
         if (empty($options['className'])) {
-            $class = Inflector::classify($filter);
+            $class = $filter;
         } else {
             $class = $options['className'];
             unset($options['className']);

--- a/src/Model/Filter/FilterMethodsTrait.php
+++ b/src/Model/Filter/FilterMethodsTrait.php
@@ -18,6 +18,20 @@ trait FilterMethodsTrait
     }
 
     /**
+     * Exists method
+     *
+     * @param string $name Name
+     * @param array $config Config
+     * @return $this
+     */
+    public function exists($name, array $config = [])
+    {
+        $this->add($name, 'Search.Exists', $config);
+
+        return $this;
+    }
+
+    /**
      * Like method
      *
      * @param string $name Name

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -75,9 +75,11 @@ class Like extends Base
             }
 
             $this->getQuery()->andWhere([$this->getConfig('fieldMode') => $conditions], $colTypes);
+
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     /**

--- a/tests/TestCase/Model/Filter/ExistsTest.php
+++ b/tests/TestCase/Model/Filter/ExistsTest.php
@@ -1,0 +1,168 @@
+<?php
+namespace Search\Test\TestCase\Model\Filter;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
+use Search\Manager;
+use Search\Model\Filter\Exists;
+
+class ExistsTest extends TestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.Search.Articles',
+    ];
+
+    /**
+     * @return void
+     */
+    public function testProcessWithFlagOn()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Exists('number', $manager);
+        $filter->setArgs(['number' => '1']);
+        $filter->setQuery($articles->find());
+        $result = $filter->process();
+
+        $this->assertTrue($result);
+
+        $this->assertRegExp(
+            '/WHERE \(Articles\.number\) IS NOT NULL$/',
+            $filter->getQuery()->sql()
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessWithFlagOff()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Exists('number', $manager);
+        $filter->setArgs(['number' => '0']);
+        $filter->setQuery($articles->find());
+        $result = $filter->process();
+
+        $this->assertTrue($result);
+
+        $this->assertRegExp(
+            '/WHERE \(Articles\.number\) IS NULL$/',
+            $filter->getQuery()->sql()
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessWithFlagOnNotNullable()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Exists('number', $manager);
+        $filter->setConfig('nullValue', '');
+
+        $filter->setArgs(['number' => 1]);
+        $filter->setQuery($articles->find());
+        $result = $filter->process();
+
+        $this->assertTrue($result);
+
+        $this->assertRegExp(
+            '/WHERE Articles\.number != \:c0$/',
+            $filter->getQuery()->sql()
+        );
+        $this->assertEquals(
+            [''],
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessWithFlagOffNotNullable()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Exists('number', $manager);
+        $filter->setConfig('nullValue', '');
+
+        $filter->setArgs(['number' => 0]);
+        $filter->setQuery($articles->find());
+        $result = $filter->process();
+
+        $this->assertTrue($result);
+
+        $this->assertRegExp(
+            '/WHERE Articles\.number = \:c0$/',
+            $filter->getQuery()->sql()
+        );
+        $this->assertEquals(
+            [''],
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessWithStringDisabled()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Exists('number', $manager);
+        $filter->setArgs(['number' => '']);
+        $filter->setQuery($articles->find());
+        $result = $filter->process();
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessMultiValueSafe()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Exists('number', $manager, ['multiValue' => true]);
+        $filter->setArgs(['number' => [0, 1]]);
+        $filter->setQuery($articles->find());
+        $result = $filter->process();
+
+        $this->assertFalse($result);
+
+        $this->assertEmpty($filter->getQuery()->clause('where'));
+        $filter->getQuery()->sql();
+        $this->assertEmpty($filter->getQuery()->getValueBinder()->bindings());
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessMultiField()
+    {
+        $articles = TableRegistry::get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Exists('exists', $manager, [
+            'field' => ['number', 'title'],
+        ]);
+        $filter->setArgs(['exists' => true]);
+        $filter->setQuery($articles->find());
+        $result = $filter->process();
+
+        $this->assertTrue($result);
+
+        $this->assertRegExp(
+            '/WHERE \(\(Articles\.number\) IS NOT NULL OR \(Articles\.title\) IS NOT NULL\)$/',
+            $filter->getQuery()->sql()
+        );
+    }
+}


### PR DESCRIPTION
Also fixed bad inflection and wrong filter result return value.

We often have to filter by content of rows (filled or not yet filled), and have a dropdown with
```php
// For a specific row field
'' => ' - show all - '
'1' => ' content set '
'0' => ' empty '
```
This Exists one takes the heavy load of a manual custom filter away as this easily does this based on the correct empty comparison for the ORM.
One improvement could be auto-detect of nullValue (schema not null => empty string), but maybe thats a bit too much overhead then.
So I settled for this compromise.

A new minor is OK?