### PR TITLE
Add beforeProcess callback to all filters

### DIFF
--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -68,6 +68,7 @@ abstract class Base
             'multiValue' => false,
             'multiValueSeparator' => null,
             'flatten' => true,
+            'beforeProcess' => null,
         ];
         $config += $defaults;
         $this->setConfig($config);
@@ -297,6 +298,19 @@ abstract class Base
     public function getQuery()
     {
         return $this->_query;
+    }
+
+    /**
+     * Calls beforeProcess callback to modify the Query
+     *
+     * @return void
+     */
+    public function beforeProcess()
+    {
+        $callback = $this->getConfig('beforeProcess');
+        if (is_callable($callback) || $callback instanceof \Closure) {
+            $this->setQuery($callback($this->getQuery()));
+        }
     }
 
     /**

--- a/src/Model/SearchTrait.php
+++ b/src/Model/SearchTrait.php
@@ -214,6 +214,7 @@ trait SearchTrait
             if ($filter->skip()) {
                 continue;
             }
+            $filter->beforeProcess();
             $result = $filter->process();
             if ($result !== false) {
                 $this->_isSearch = true;

--- a/tests/TestCase/Model/Filter/BaseTest.php
+++ b/tests/TestCase/Model/Filter/BaseTest.php
@@ -156,6 +156,33 @@ class BaseTest extends TestCase
     /**
      * @return void
      */
+    public function testBeforeProcess()
+    {
+        $query = $this->Manager->getRepository()->find();
+
+        $callback = $this->getMockBuilder(\stdClass::class)
+            ->setMethods(['__invoke'])
+            ->getMock();
+
+        $callback->expects($this->once())
+            ->method('__invoke')
+            ->willReturn($query);
+
+        $filter = new TestFilter(
+            'field',
+            $this->Manager,
+            [
+                'alwaysRun' => true,
+                'beforeProcess' => $callback
+            ]
+        );
+        $filter->setQuery($query);
+        $filter->beforeProcess();
+    }
+
+    /**
+     * @return void
+     */
     public function testValue()
     {
         $filter = new TestFilter(


### PR DESCRIPTION
Closes #249
Allows manipulation of the query as "setup" for the filters.

Should I modify `testProcessFilters` to expect beforeProcess or How should I test in SearchBehavior?