### PR TITLE
Processor

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -329,7 +329,9 @@ The following options are supported by all filters except `Callback` and `Finder
 - `beforeProcess` (`callable`, defaults to `null`) A callable which can be used
   to modify the query before the main `process()` method of filter is run.
   It receives `$query` and `$args` as arguments. You can use the callback for e.g.
-  to setup joins or contains on the query.
+  to setup joins or contains on the query. If the callback returns `false` then
+  processing of the filter will be skipped. If it returns `array` it will be used
+  as filter arguments.
 
 #### `Boolean`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -326,11 +326,16 @@ The following options are supported by all filters except `Callback` and `Finder
 - `defaultValue` (`mixed`, defaults to `null`) The default value that is being
   used in case the value passed for the corresponding field is invalid or missing.
 
+- `beforeProcess` (`callable`, defaults to `null`) A callable which can be used
+  to modify the query before the main `process()` method of filter is run.
+  It receives `$query` and `$args` as arguments. You can use the callback for e.g.
+  to setup joins or contains on the query.
+
 #### `Boolean`
 
 - `mode` (`string`, defaults to `OR`) The conditional mode to use when matching
   against multiple fields. Valid values are `OR` and `AND`.
-  
+
 #### `Exists`
 
 - `mode` (`string`, defaults to `OR`) The conditional mode to use when matching
@@ -409,10 +414,10 @@ Set it to an empty string there to check via `=`/`!=` instead of `IS NULL`/`IS N
 - `multiValue` (`bool`, defaults to `false`) Defines whether the filter accepts
   multiple values. If disabled, and multiple values are being passed, the filter
   will fall back to using the default value defined by the `defaultValue` option.
-  
+
 - `multiValueSeparator` (`string`, defaults to `null`) Defines whether the filter should
   auto-tokenize multiple values using a specific separator string. If disabled, the data
-  must be an in form of an array.  
+  must be an in form of an array.
 
 - `mode` (`string`, defaults to `OR`) The conditional mode to use when matching
   against multiple fields. Valid values are `OR` and `AND`.
@@ -472,9 +477,9 @@ class MyCustomFilter extends \Search\Model\Filter\Base
     public function process()
     {
         // return false if you want to skip modifying the query based on some condition.
-        
+
         // Use $this->query() to get query instance and modify it as needed.
-        
+
         return true;
     }
 }

--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -1,6 +1,4 @@
 <?php
-declare(strict_types=1);
-
 namespace Search\Model\Behavior;
 
 use Cake\Core\Configure;
@@ -39,7 +37,7 @@ class SearchBehavior extends Behavior
      * @param array $config Config
      * @return void
      */
-    public function initialize(array $config): void
+    public function initialize(array $config)
     {
         parent::initialize($config);
 

--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Search\Model\Behavior;
 
@@ -38,7 +39,7 @@ class SearchBehavior extends Behavior
      * @param array $config Config
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         parent::initialize($config);
 
@@ -76,10 +77,10 @@ class SearchBehavior extends Behavior
     /**
      * Return the empty values.
      *
-     * @return array
+     * @return array|null
      */
     protected function _emptyValues()
     {
-        return (array)$this->getConfig('emptyValues');
+        return $this->getConfig('emptyValues');
     }
 }

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -318,7 +318,15 @@ abstract class Base
 
         $beforeProcess = $this->getConfig('beforeProcess');
         if (is_callable($beforeProcess)) {
-            $beforeProcess($this->getQuery(), $this->getArgs());
+            $return = $beforeProcess($this->getQuery(), $this->getArgs());
+
+            if ($return === false) {
+                return false;
+            }
+
+            if (is_array($return)) {
+                $this->setArgs($return);
+            }
         }
 
         return $this->process();

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -303,9 +303,11 @@ abstract class Base
     /**
      * Run the filter.
      *
+     * @param \Cake\Datasource\QueryInterface $query Query instance.
+     * @param array $args Filter arguments.
      * @return bool True if processed, false if skipped
      */
-    public function __invoke($query, $args)
+    public function __invoke(QueryInterface $query, array $args)
     {
         $this->setQuery($query);
         $this->setArgs($args);

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -68,6 +68,7 @@ abstract class Base
             'multiValue' => false,
             'multiValueSeparator' => null,
             'flatten' => true,
+            'beforeProcess' => null,
         ];
         $config += $defaults;
         $this->setConfig($config);
@@ -297,6 +298,28 @@ abstract class Base
     public function getQuery()
     {
         return $this->_query;
+    }
+
+    /**
+     * Run the filter.
+     *
+     * @return bool True if processed, false if skipped
+     */
+    public function __invoke($query, $args)
+    {
+        $this->setQuery($query);
+        $this->setArgs($args);
+
+        if ($this->skip()) {
+            return false;
+        }
+
+        $beforeProcess = $this->getConfig('beforeProcess');
+        if (is_callable($beforeProcess)) {
+            $beforeProcess($this->getQuery(), $this->getArgs());
+        }
+
+        return $this->process();
     }
 
     /**

--- a/src/Model/SearchTrait.php
+++ b/src/Model/SearchTrait.php
@@ -72,6 +72,11 @@ trait SearchTrait
         return $query;
     }
 
+    /**
+     * Get filters processor instance.
+     *
+     * @return \Search\Processor
+     */
     public function processor()
     {
         if ($this->_processor === null) {

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -8,7 +8,7 @@ use Search\Model\Filter\FilterCollectionInterface;
 class Processor
 {
     /**
-     * The filtered and flattend params from query string used for filtering.
+     * The filtered and flattend params used for filtering.
      *
      * @var array
      */
@@ -25,8 +25,8 @@ class Processor
      * Processes the given filters.
      *
      * @param \Search\Model\Filter\FilterCollectionInterface $filters The filters to process.
-     * @param \Cake\Datasource\QueryInterface $query The query to pass to the filters.
-     * @param array $params The parameters to pass to the filters.
+     * @param \Cake\Datasource\QueryInterface $query The query to be modified by the filters.
+     * @param array $params The search parameters to pass to the filters.
      * @return bool True is $query was modified by filters else false.
      */
     public function process(FilterCollectionInterface $filters, QueryInterface $query, array $params)
@@ -38,13 +38,7 @@ class Processor
         $filtered = false;
 
         foreach ($filters as $filter) {
-            $filter->setQuery($query);
-            $filter->setArgs($params);
-
-            if ($filter->skip()) {
-                continue;
-            }
-            $result = $filter->process();
+            $result = $filter($query, $params);
             if ($result !== false) {
                 $filtered = true;
             }

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -1,0 +1,159 @@
+<?php
+namespace Search;
+
+use Cake\Datasource\QueryInterface;
+use Cake\Utility\Hash;
+use Search\Model\Filter\FilterCollectionInterface;
+
+class Processor
+{
+    /**
+     * The filtered and flattend params from query string used for filtering.
+     *
+     * @var array
+     */
+    protected $_searchParams = [];
+
+    /**
+     * Values that should be treated as empty in search params.
+     *
+     * @var array
+     */
+    protected $_emptyValues = ['', false, null];
+
+    /**
+     * Processes the given filters.
+     *
+     * @param \Search\Model\Filter\FilterCollectionInterface $filters The filters to process.
+     * @param \Cake\Datasource\QueryInterface $query The query to pass to the filters.
+     * @param array $params The parameters to pass to the filters.
+     * @return bool True is $query was modified by filters else false.
+     */
+    public function process(FilterCollectionInterface $filters, QueryInterface $query, array $params)
+    {
+        $params = $this->_flattenParams($params, $filters);
+        $params = $this->_extractParams($params, $filters);
+
+        $this->_searchParams = $params;
+        $filtered = false;
+
+        foreach ($filters as $filter) {
+            $filter->setQuery($query);
+            $filter->setArgs($params);
+
+            if ($filter->skip()) {
+                continue;
+            }
+            $result = $filter->process();
+            if ($result !== false) {
+                $filtered = true;
+            }
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * Set values that should be treated as empty by filters.
+     *
+     * @param array $emptyValues Values list.
+     * @return $this
+     */
+    public function setEmptyValues(array $emptyValues)
+    {
+        $this->_emptyValues = $emptyValues;
+
+        return $this;
+    }
+
+    /**
+     * Get params from query string to be used for filtering.
+     *
+     * @return array
+     */
+    public function searchParams()
+    {
+        return $this->_searchParams;
+    }
+
+    /**
+     * Flattens a parameters array, so that possible aliased parameter
+     * keys that are provided in a nested fashion, are being grouped
+     * using flat keys.
+     *
+     * ### Example:
+     *
+     * The following parameters array:
+     *
+     * ```
+     * [
+     *     'Alias' => [
+     *         'field' => 'value'
+     *         'otherField' => [
+     *             'value',
+     *             'otherValue'
+     *         ]
+     *     ],
+     *     'field' => 'value'
+     * ]
+     * ```
+     *
+     * would return as
+     *
+     * ```
+     * [
+     *     'Alias.field' => 'value',
+     *     'Alias.otherField' => [
+     *         'value',
+     *         'otherValue'
+     *     ],
+     *     'field' => 'value'
+     * ]
+     * ```
+     *
+     * @param array $params The parameters array to flatten.
+     * @param \Search\Model\Filter\FilterCollectionInterface $filters Filter collection instance.
+     * @return array The flattened parameters array.
+     */
+    protected function _flattenParams(array $params, FilterCollectionInterface $filters)
+    {
+        $flattened = [];
+        foreach ($params as $key => $value) {
+            if (!is_array($value) ||
+                (!empty($filters[$key]) && $filters[$key]->getConfig('flatten') === false)
+            ) {
+                $flattened[$key] = $value;
+                continue;
+            }
+
+            foreach ($value as $childKey => $childValue) {
+                if (!is_numeric($childKey)) {
+                    $flattened[$key . '.' . $childKey] = $childValue;
+                } else {
+                    $flattened[$key][$childKey] = $childValue;
+                }
+            }
+        }
+
+        return $flattened;
+    }
+
+    /**
+     * Extracts all parameters for which a filter with a matching field
+     * name exists.
+     *
+     * @param array $params The parameters array to extract from.
+     * @param \Search\Model\Filter\FilterCollectionInterface $filters Filter collection.
+     * @return array The extracted parameters.
+     */
+    protected function _extractParams($params, FilterCollectionInterface $filters)
+    {
+        $emptyValues = $this->_emptyValues;
+
+        $nonEmptyParams = Hash::filter($params, function ($val) use ($emptyValues) {
+            return !in_array($val, $emptyValues, true);
+        });
+
+        return array_intersect_key($nonEmptyParams, iterator_to_array($filters));
+    }
+}

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -140,7 +140,7 @@ class Processor
      * @param \Search\Model\Filter\FilterCollectionInterface $filters Filter collection.
      * @return array The extracted parameters.
      */
-    protected function _extractParams($params, FilterCollectionInterface $filters)
+    protected function _extractParams(array $params, FilterCollectionInterface $filters)
     {
         $emptyValues = $this->_emptyValues;
 

--- a/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
@@ -95,11 +95,11 @@ class SearchBehaviorTest extends TestCase
             ->setMethods(['setArgs', 'skip', 'process', 'setQuery'])
             ->getMock();
         $filter
-            ->expects($this->at(0))
+            ->expects($this->once())
             ->method('setArgs')
             ->with($params);
         $filter
-            ->expects($this->at(1))
+            ->expects($this->once())
             ->method('setQuery')
             ->with($query);
         $filter
@@ -115,11 +115,11 @@ class SearchBehaviorTest extends TestCase
             ->setMethods(['setArgs', 'skip', 'process', 'setQuery'])
             ->getMock();
         $filter2
-            ->expects($this->at(0))
+            ->expects($this->once())
             ->method('setArgs')
             ->with($params);
         $filter2
-            ->expects($this->at(1))
+            ->expects($this->once())
             ->method('setQuery')
             ->with($query);
         $filter2

--- a/tests/TestCase/Model/Filter/BaseTest.php
+++ b/tests/TestCase/Model/Filter/BaseTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Search\Test\TestCase\Model\Filter;
 
+use Cake\ORM\Query;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Search\Manager;
@@ -262,5 +263,22 @@ class BaseTest extends TestCase
         );
 
         $this->assertEquals('field', $filter->field());
+    }
+
+    /**
+     * @return void
+     */
+    public function testBeforeProcessCallback()
+    {
+        $filter = new TestFilter(
+            'field',
+            $this->Manager,
+            ['beforeProcess' => function ($query, $params) {
+                $query->where($params);
+            }]
+        );
+
+        $filter($this->Manager->getRepository()->find(), ['field' => 'bar']);
+        $this->assertNotEmpty($filter->getQuery()->clause('where'));
     }
 }


### PR DESCRIPTION
While looking into #249, the fact that the guts for filter processing were tucked away in a trait irked me. So I moved the relevant code into a separate class.

Making the filters invokeable is an elegant solution for running the "beforeProcess" callback and also not having to call various other methods of the filter explicitly before running `process()`.