### PR TITLE
Pass filter instance too to beforeProcess callback.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -332,12 +332,12 @@ The following options are supported by all filters except `Callback` and `Finder
   to setup joins or contains on the query. If the callback returns `false` then
   processing of the filter will be skipped. If it returns `array` it will be used
   as filter arguments.
-  
+
     ```php
     // PostsTable::initialize()
         $searchManager->like('q', [
             'fields' => ['Posts.title', 'Authors.title'],
-            'beforeProcess' => function (\Cake\ORM\Query $query, array $args) {
+            'beforeProcess' => function (\Cake\ORM\Query $query, array $args, \Search\Model\Filter\Base $filter) {
                 $query->contain('Authors');
             },
         ]);

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -4,6 +4,7 @@ namespace Search\Model\Filter;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Datasource\QueryInterface;
 use Search\Manager;
+use UnexpectedValueException;
 
 /**
  * Base class for search type classes.
@@ -317,7 +318,11 @@ abstract class Base
         }
 
         $beforeProcess = $this->getConfig('beforeProcess');
-        if (is_callable($beforeProcess)) {
+        if ($beforeProcess !== null) {
+            if (!is_callable($beforeProcess)) {
+                throw new UnexpectedValueException('Value for "beforeProcess" config must be a valid callable');
+            }
+
             $return = $beforeProcess($this->getQuery(), $this->getArgs(), $this);
 
             if ($return === false) {

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -318,20 +318,20 @@ abstract class Base
         }
 
         $beforeProcess = $this->getConfig('beforeProcess');
-        if ($beforeProcess !== null) {
-            if (!is_callable($beforeProcess)) {
-                throw new UnexpectedValueException('Value for "beforeProcess" config must be a valid callable');
-            }
+        if ($beforeProcess === null) {
+            return $this->process();
+        }
 
-            $return = $beforeProcess($this->getQuery(), $this->getArgs(), $this);
+        if (!is_callable($beforeProcess)) {
+            throw new UnexpectedValueException('Value for "beforeProcess" config must be a valid callable');
+        }
 
-            if ($return === false) {
-                return false;
-            }
-
-            if (is_array($return)) {
-                $this->setArgs($return);
-            }
+        $return = $beforeProcess($this->getQuery(), $this->getArgs(), $this);
+        if ($return === false) {
+            return false;
+        }
+        if (is_array($return)) {
+            $this->setArgs($return);
         }
 
         return $this->process();

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -318,7 +318,7 @@ abstract class Base
 
         $beforeProcess = $this->getConfig('beforeProcess');
         if (is_callable($beforeProcess)) {
-            $return = $beforeProcess($this->getQuery(), $this->getArgs());
+            $return = $beforeProcess($this->getQuery(), $this->getArgs(), $this);
 
             if ($return === false) {
                 return false;


### PR DESCRIPTION
This maintains consistency with argument received by callback of Callback filter.