### PR TITLE
Allow persisting nested query params (e.g. scoped pagination)

### DIFF
--- a/src/Controller/Component/PrgComponent.php
+++ b/src/Controller/Component/PrgComponent.php
@@ -65,6 +65,7 @@ class PrgComponent extends Component
 
         $params = $this->_filterParams();
         if ($params) {
+            $params = Hash::expand($params);
             $url .= '?' . http_build_query($params);
         }
 

--- a/tests/TestCase/Controller/Component/PrgComponentTest.php
+++ b/tests/TestCase/Controller/Component/PrgComponentTest.php
@@ -155,6 +155,32 @@ class SearchComponentTest extends TestCase
     /**
      * @return void
      */
+    public function testInitializePostWithNestedQueryString()
+    {
+        $this->Controller->request = $this->Controller->request->withQueryParams([
+            'scope' => [
+                'sort' => 'created',
+                'direction' => 'desc',
+                'page' => 9,
+            ],
+        ]);
+        $this->Controller->request = $this->Controller->request->withAttribute('params', [
+            'controller' => 'Posts',
+            'action' => 'index',
+            'pass' => ['pass'],
+        ]);
+        $this->Controller->request = $this->Controller->request->withRequestTarget('/Posts/index/pass');
+        $this->Controller->request = $this->Controller->request->withData('foo', 'bar');
+        $this->Controller->request = $this->Controller->request->withEnv('REQUEST_METHOD', 'POST');
+
+        $this->Prg->configShallow('queryStringWhitelist', ['scope.sort', 'scope.direction']);
+        $response = $this->Prg->startup();
+        $this->assertEquals('http://localhost/Posts/index/pass?foo=bar&scope%5Bsort%5D=created&scope%5Bdirection%5D=desc', $response->getHeaderLine('Location'));
+    }
+
+    /**
+     * @return void
+     */
     public function testInitializePostWithQueryStringWhitelistEmpty()
     {
         $this->Controller->request = $this->Controller->request->withQueryParams([


### PR DESCRIPTION
Expands an array that was previously flattened with Hash::flatten():