### PR TITLE
Don't camelize $name if it's an FQCN

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -101,8 +101,10 @@ class Manager
     {
         if ($name === self::DEFAULT_COLLECTION) {
             $class = $this->_collectionClass;
-        } else {
+        } else if (strpos($name, '\\') === false) {
             $class = Inflector::camelize(str_replace('-', '_', $name));
+        } else {
+            $class = $name;
         }
 
         $className = App::className($class, 'Model/Filter', 'Collection');

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -101,7 +101,7 @@ class Manager
     {
         if ($name === self::DEFAULT_COLLECTION) {
             $class = $this->_collectionClass;
-        } else if (strpos($name, '\\') === false) {
+        } elseif (strpos($name, '\\') === false) {
             $class = Inflector::camelize(str_replace('-', '_', $name));
         } else {
             $class = $name;


### PR DESCRIPTION
The namespace root of our application starts with a lowercase "u".  When passing a fully qualified class name as in the example below, the "u" is capitalised to "U" as part of the `Inflector::camelize()" call in `src/Manager.php` on line 105:

```php
$accounts = $this->Accounts
    ->find('search', [
        'collection' => AccountsCollection::class,
        'search' => $this->getRequest()->getQuery(),
    ]);
```

The capitalisation of the namespace root obviously results in the class not being findable.

The application-side "fix" for this is to prefix it with a `\`, so that the code becomes `'collection' => '\\' . AccountsCollection::class,` in which case the strings ends up not being camelised in the same manner.  

However, perhaps a fix as implemented in this PR could make more sense for a larger number of users.  The basic premise of the work done is that if the string contains a `\`, it assumed to be an FQCN, and thus doesn't need to be camelised at all.

