### PR TITLE
Use dedicated coverage run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,17 @@ matrix:
   fast_finish: true
 
   include:
-    - php: 7.2
+    - php: 7.4
       env: CHECKS=1 DEFAULT=0
 
     - php: 7.2
       env: PREFER_LOWEST=1
 
+    - php: 7.3
+      env: COVERAGE=1 DEFAULT=0 DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test'
+
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION != 7.4 ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $COVERAGE != 1 ]]; then phpenv config-rm xdebug.ini; fi
 
   - if [[ $PREFER_LOWEST != 1 ]]; then composer install --no-interaction ; fi
   - if [[ $PREFER_LOWEST == 1 ]]; then composer update --prefer-lowest --prefer-stable --no-interaction ; fi
@@ -39,9 +42,9 @@ before_script:
   - if [[ $DB == 'pgsql' ]]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi
 
 script:
-  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.3 ]]; then vendor/bin/phpunit; fi
+  - if [[ $DEFAULT == 1 ]]; then vendor/bin/phpunit; fi
   - |
-      if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.3 ]]; then
+      if [[ $COVERAGE == 1 ]]; then
         mkdir -p build/logs
         vendor/bin/phpunit --coverage-clover=build/logs/clover.xml
       fi
@@ -51,7 +54,7 @@ script:
 
 after_success:
   - |
-      if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.3 ]]; then
+      if [[ $COVERAGE == 1 ]]; then
         wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.1.0/php-coveralls.phar
         chmod +x php-coveralls.phar
         ./php-coveralls.phar


### PR DESCRIPTION
The complex logic killed the coverage it seems.
This simplifies it.

checks should run with highest setting to see deprecations in the language  earlier.