### PR TITLE
Make search compatible with authorization component

### DIFF
--- a/src/Controller/Component/SearchComponent.php
+++ b/src/Controller/Component/SearchComponent.php
@@ -84,7 +84,7 @@ class SearchComponent extends Component
         if (!$this->_isSearchAction()) {
             return;
         }
-        
+
         if ($this->getController()->getRequest()->is('post') && $this->_isSearchAction()) {
             $url = $this->getController()->getRequest()->getPath();
 
@@ -94,7 +94,7 @@ class SearchComponent extends Component
                 $url .= '?' . http_build_query($params);
             }
 
-            return $this->_registry->getController()->redirect($url);    
+            return $this->_registry->getController()->redirect($url);
         }
 
         $controller = $this->getController();

--- a/src/Controller/Component/SearchComponent.php
+++ b/src/Controller/Component/SearchComponent.php
@@ -68,19 +68,7 @@ class SearchComponent extends Component
      */
     public function startup(): ?Response
     {
-        if (!$this->getController()->getRequest()->is('post') || !$this->_isSearchAction()) {
-            return null;
-        }
-
-        $url = $this->getController()->getRequest()->getPath();
-
-        $params = $this->_filterParams();
-        if ($params) {
-            $params = Hash::expand($params);
-            $url .= '?' . http_build_query($params);
-        }
-
-        return $this->_registry->getController()->redirect($url);
+        return null;
     }
 
     /**
@@ -95,6 +83,18 @@ class SearchComponent extends Component
     {
         if (!$this->_isSearchAction()) {
             return;
+        }
+        
+        if ($this->getController()->getRequest()->is('post') && $this->_isSearchAction()) {
+            $url = $this->getController()->getRequest()->getPath();
+
+            $params = $this->_filterParams();
+            if ($params) {
+                $params = Hash::expand($params);
+                $url .= '?' . http_build_query($params);
+            }
+
+            return $this->_registry->getController()->redirect($url);    
         }
 
         $controller = $this->getController();


### PR DESCRIPTION
The Search plugin does a redirect in its startup method. Because this event happens before controller action and aborts the request, the skipAuthorization() and authorize() calls in controller actions are never reached on the redirect response. cakephp/authorization#128

Moving the logic from the startup() to beforeRender() solves the issue.
#258 #265