### PR TITLE
Use stable versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,5 @@
             "@psalm"
         ],
         "test": "phpunit"
-    },
-    "minimum-stability": "beta",
-    "prefer-stable": true
+    }
 }


### PR DESCRIPTION
This seems to require first

    "muffin/webservice": "^3.0"

being released as stable.