### PR TITLE
Update Readme.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -495,7 +495,7 @@ class MyCustomFilter extends \Search\Model\Filter\Base
     {
         // return false if you want to skip modifying the query based on some condition.
 
-        // Use $this->query() to get query instance and modify it as needed.
+        // Use $this->getQuery() to get query instance and modify it as needed.
 
         return true;
     }


### PR DESCRIPTION
The section on custom query filters refers to accessing $this->query() when you can see that $this->getQuery() is what is implemented in the plugin. $this->query() fails when ran in classes extending \Search\Model\Filter\Base, as currently instructed in Readme.md.