### PR TITLE
Dont drop passed params for reset

### DIFF
--- a/src/View/Helper/SearchHelper.php
+++ b/src/View/Helper/SearchHelper.php
@@ -86,8 +86,11 @@ class SearchHelper extends Helper
             unset($query[$param]);
         }
 
-        return [
+        $url = (array)$this->getView()->getRequest()->getParam('pass');
+        $url += [
             '?' => $query,
         ];
+
+        return $url;
     }
 }

--- a/tests/TestCase/View/Helper/SearchHelperTest.php
+++ b/tests/TestCase/View/Helper/SearchHelperTest.php
@@ -92,6 +92,37 @@ class SearchHelperTest extends TestCase
     /**
      * @return void
      */
+    public function testResetUrlWithPassedParams()
+    {
+        $request = new ServerRequest([
+            'url' => '/controller/action/my-passed?limit=5&sort=x&direction=asc&foo=baz&bar=1',
+        ]);
+        $request = $request->withParam('pass', ['my-passed']);
+
+        $this->view = new View($request);
+        $this->searchHelper = new SearchHelper($this->view, []);
+
+        $params = [
+            'foo' => 'baz',
+            'bar' => '1',
+        ];
+        $this->view->set('_searchParams', $params);
+
+        $result = $this->searchHelper->resetUrl();
+        $expected = [
+            'my-passed',
+            '?' => [
+                'limit' => '5',
+                'sort' => 'x',
+                'direction' => 'asc',
+            ],
+        ];
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @return void
+     */
     public function testResetUrlWithPaginator()
     {
         $request = new ServerRequest([


### PR DESCRIPTION
We forgot this at the time

When you have passed params, e.g. /controller/index/my-filter?query=xyz
Then the reset link would drop the "my-filter" and create 404s (when the passed params are expected/required).

This fixes it.