### PR TITLE
Update "getTable" to "table"

### DIFF
--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -63,7 +63,7 @@ class SearchBehavior extends Behavior
         $defaultCollectionClass = sprintf(
             '%s\Model\Filter\%sCollection',
             Configure::read('App.namespace'),
-            $this->getTable()->getAlias()
+            $this->table()->getAlias()
         );
         if (class_exists($defaultCollectionClass)) {
             $this->_collectionClass = $defaultCollectionClass;


### PR DESCRIPTION
I request the update of the plugin to adapt to the new changes in cakephp 4.2.
In particular, get the use of getTable for Table, as shown in 
https://book.cakephp.org/4.next/en/appendices/4-2-migration-guide.html#orm