### PR TITLE
Bake task for filter collections

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -5,6 +5,9 @@ linters:
     extensions: 'php'
     fixer: true
 
+files:
+  ignore: ['tests/comparisons/*']
+
 fixers:
   enable: true
   workflow: commit

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,8 @@
         "cakephp/cakephp": "^4.0"
     },
     "require-dev": {
+        "cakephp/twig-view": "^1.1.1",
+        "cakephp/bake": "^2.2.0",
         "phpunit/phpunit": "~8.5.0",
         "cakephp/cakephp-codesniffer": "^4.0",
         "muffin/webservice": "^3.0@beta"
@@ -45,8 +47,8 @@
         "issues": "https://github.com/FriendsOfCake/search/issues"
     },
     "scripts": {
-        "cs-check": "phpcs -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP src/ tests/",
-        "cs-fix": "phpcbf --standard=vendor/cakephp/cakephp-codesniffer/CakePHP src/ tests/",
+        "cs-check": "phpcs -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP --ignore=/tests/comparisons/ src/ tests/",
+        "cs-fix": "phpcbf --standard=vendor/cakephp/cakephp-codesniffer/CakePHP --ignore=/tests/comparisons/ src/ tests/",
         "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.12 psalm/phar:^3.8 && mv composer.backup composer.json",
         "phpstan": "phpstan.phar analyse",
         "psalm": "psalm.phar",

--- a/docs/README.md
+++ b/docs/README.md
@@ -526,6 +526,10 @@ When the FormProtection component is activated for the whole controller, it shou
 $this->FormProtection->setConfig('unlockedActions', ['index']);
 ```
 
+## Bake Filters
+
+With the `filter_collection` bake task, you can generate filter collection classes easily.
+
 ## Tips
 
 ### IDE compatibility

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ parameters:
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
     paths:
-        - src
+        - src/
     bootstrapFiles:
         - tests/bootstrap.php
     ignoreErrors:

--- a/src/Command/BakeFilterCollectionCommand.php
+++ b/src/Command/BakeFilterCollectionCommand.php
@@ -10,6 +10,7 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
 use Cake\Database\Exception;
+use Cake\ORM\Table;
 
 /**
  * For generating filter collection classes.
@@ -49,6 +50,15 @@ class BakeFilterCollectionCommand extends BakeCommand
             'string',
             'char',
         ],
+    ];
+
+    /**
+     * @var string[]
+     */
+    protected $_ignoreFields = [
+        'lft',
+        'rght',
+        'password',
     ];
 
     /**
@@ -177,7 +187,7 @@ class BakeFilterCollectionCommand extends BakeCommand
 
         $fields = [];
         foreach ($columns as $column) {
-            if ($column === $table->getPrimaryKey() || $column === 'password') {
+            if ($this->shouldSkip($column, $table)) {
                 continue;
             }
 
@@ -221,5 +231,19 @@ class BakeFilterCollectionCommand extends BakeCommand
         ]);
 
         return $parser;
+    }
+
+    /**
+     * Checks if this column should be skipped.
+     *
+     * This hook method can be extended and customized as per application needs.
+     *
+     * @param string $column Column name
+     * @param \Cake\ORM\Table $table Table instance
+     * @return bool
+     */
+    protected function shouldSkip(string $column, Table $table): bool
+    {
+        return $column === $table->getPrimaryKey() || in_array($column, $this->_ignoreFields, true);
     }
 }

--- a/src/Command/BakeFilterCollectionCommand.php
+++ b/src/Command/BakeFilterCollectionCommand.php
@@ -1,0 +1,225 @@
+<?php
+declare(strict_types=1);
+
+namespace Search\Command;
+
+use Bake\Command\BakeCommand;
+use Bake\Utility\TemplateRenderer;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Core\Configure;
+use Cake\Database\Exception;
+
+/**
+ * For generating filter collection classes.
+ *
+ * E.g.:
+ * src/Model/Filter/MyCustomFilterCollection.php
+ * src/Model/Filter/Admin/UsersFilterCollection.php
+ */
+class BakeFilterCollectionCommand extends BakeCommand
+{
+    /**
+     * Task name used in path generation.
+     *
+     * @var string
+     */
+    public $pathFragment = 'Model/Filter/';
+
+    /**
+     * @var string
+     */
+    protected $_name;
+
+    /**
+     * @var string[][]
+     */
+    protected $_map = [
+        'value' => [
+            'integer',
+            'tinyinteger',
+            'biginteger',
+            'smallinteger',
+            'uuid',
+            'binaryuuid',
+            'boolean',
+        ],
+        'like' => [
+            'string',
+            'char',
+        ],
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public static function defaultName(): string
+    {
+        return 'bake filter_collection';
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @param \Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @return int|null The exit code or null for success
+     */
+    public function execute(Arguments $args, ConsoleIo $io): ?int
+    {
+        $this->extractCommonProperties($args);
+
+        $this->bake((string)$args->getArgumentAt(0), $args, $io);
+
+        return static::CODE_SUCCESS;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function bake(string $name, Arguments $args, ConsoleIo $io): void
+    {
+        $this->_name = $name;
+
+        $fields = $this->getFields($name, $args->getArgumentAt(1));
+        $templateData = $this->templateData($args) + [
+            'fields' => $fields,
+        ];
+
+        $renderer = new TemplateRenderer((string)$args->getOption('theme'));
+        $renderer->set('name', $name);
+        $renderer->set($templateData);
+        $contents = $renderer->generate($this->template());
+
+        $filename = $this->getPath($args) . $this->fileName($name);
+        $io->createFile($filename, $contents, (bool)$args->getOption('force'));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function template(): string
+    {
+        return 'Search.FilterCollection/filter_collection';
+    }
+
+    /**
+     * @param \Cake\Console\Arguments $arguments Arguments
+     * @return array
+     */
+    public function templateData(Arguments $arguments): array
+    {
+        $name = $this->_name;
+        $namespace = Configure::read('App.namespace');
+        $pluginPath = '';
+        if ($this->plugin) {
+            $namespace = $this->_pluginNamespace($this->plugin);
+            $pluginPath = $this->plugin . '.';
+        }
+
+        $namespace .= '\\Model\\Filter';
+
+        $namespacePart = null;
+        if (strpos($name, '/') !== false) {
+            $parts = explode('/', $name);
+            $name = array_pop($parts);
+            $namespacePart = implode('\\', $parts);
+        }
+        if ($namespacePart) {
+            $namespace .= '\\' . $namespacePart;
+        }
+
+        $prefix = $arguments->getOption('prefix');
+        if ($prefix) {
+            $namespace .= '\\' . $prefix;
+        }
+
+        return [
+            'plugin' => $this->plugin,
+            'pluginPath' => $pluginPath,
+            'namespace' => $namespace,
+            'prefix' => $prefix,
+            'name' => $name,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function name(): string
+    {
+        return 'filter_collection';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function fileName(string $name): string
+    {
+        return $name . 'FilterCollection.php';
+    }
+
+    /**
+     * @param string $name Name of filter collection
+     * @param string|null $modelName Model name
+     * @return array
+     */
+    protected function getFields(string $name, ?string $modelName): array
+    {
+        $model = $modelName ?: $name;
+        try {
+            $table = $this->getTableLocator()->get($model);
+            $columns = $table->getSchema()->columns();
+        } catch (Exception $exception) {
+            return [];
+        }
+
+        $fields = [];
+        foreach ($columns as $column) {
+            if ($column === $table->getPrimaryKey() || $column === 'password') {
+                continue;
+            }
+
+            $columnInfo = (array)$table->getSchema()->getColumn($column);
+            $type = $columnInfo['type'];
+            if (in_array($type, $this->_map['value'], true)) {
+                $fields[$column] = 'value';
+                continue;
+            }
+
+            if (in_array($type, $this->_map['like'], true)) {
+                $fields[$column] = 'like';
+                continue;
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Gets the option parser instance and configures it.
+     *
+     * @param \Cake\Console\ConsoleOptionParser $parser The option parser to update.
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        $parser = $this->_setCommonOptions($parser);
+
+        $parser->setDescription(
+            'Bake filter collections for a model search functionality.'
+        )->addArgument('name', [
+            'help' => 'Name of the filter collection to bake. You can use Plugin.name '
+            . 'as a shortcut for plugin baking. By default this will also try to find the model based on that name.',
+            'required' => true,
+        ])->addArgument('model', [
+            'help' => 'Model to use if you use a custom collection name that does not match the model.',
+        ])->addOption('prefix', [
+            'help' => 'The namespace prefix to use.',
+            'default' => false,
+        ]);
+
+        return $parser;
+    }
+}

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -92,7 +92,8 @@ abstract class Base
 
         if (
             !is_string($config['name']) ||
-            (empty($config['name']) && $config['name'] !== '0')
+            (empty($config['name']) &&
+            $config['name'] !== '0')
         ) {
             throw new \InvalidArgumentException(
                 'The `$name` argument is invalid. Expected a non-empty string.'

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -27,11 +27,4 @@ class Plugin extends BasePlugin
      * @var bool
      */
     protected $routesEnabled = false;
-
-    /**
-     * Console middleware
-     *
-     * @var bool
-     */
-    protected $consoleEnabled = false;
 }

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -122,7 +122,8 @@ class Processor
         foreach ($params as $key => $value) {
             if (
                 !is_array($value) ||
-                (!empty($filters[$key]) && $filters[$key]->getConfig('flatten') === false)
+                (!empty($filters[$key]) &&
+                $filters[$key]->getConfig('flatten') === false)
             ) {
                 $flattened[$key] = $value;
                 continue;

--- a/templates/bake/FilterCollection/filter_collection.twig
+++ b/templates/bake/FilterCollection/filter_collection.twig
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use Search\Model\Filter\FilterCollection;
+
+class {{ name }}FilterCollection extends FilterCollection
+{
+    /**
+     * @return void
+     */
+    public function initialize(): void
+    {
+{% for field, type in fields %}
+        $this->{{ type }}('{{ field }}');
+{% endfor %}
+    }
+}

--- a/tests/TestApp/Application.php
+++ b/tests/TestApp/Application.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Search\Test\TestApp;
+
+use Cake\Http\BaseApplication;
+use Cake\Http\MiddlewareQueue;
+use Cake\Routing\RouteBuilder;
+
+class Application extends BaseApplication
+{
+    public function middleware(MiddlewareQueue $middleware): MiddlewareQueue
+    {
+        return $middleware;
+    }
+
+    public function routes(RouteBuilder $routes): void
+    {
+    }
+
+    public function bootstrap(): void
+    {
+        $this->addPlugin('Bake', ['boostrap' => true]);
+    }
+}

--- a/tests/TestCase/Command/BakeFilterCollectionCommandTest.php
+++ b/tests/TestCase/Command/BakeFilterCollectionCommandTest.php
@@ -1,0 +1,109 @@
+<?php
+declare(strict_types=1);
+
+namespace Search\Test\TestCase\Command;
+
+use Cake\Console\BaseCommand;
+use Cake\Console\ConsoleInput;
+use Cake\Core\Plugin;
+use Cake\Filesystem\Folder;
+use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\StringCompareTrait;
+use Cake\TestSuite\TestCase;
+
+class BakeFilterCollectionCommandTest extends TestCase
+{
+    use StringCompareTrait;
+    use ConsoleIntegrationTestTrait;
+
+    /**
+     * @var string[]
+     */
+    protected $fixtures = [
+        'core.Posts',
+    ];
+
+    /**
+     * @var string
+     */
+    protected $_generatedBasePath;
+
+    /**
+     * setup method
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->_compareBasePath = Plugin::path('Search') . 'tests' . DS . 'comparisons' . DS . 'Filter' . DS;
+        $this->_generatedBasePath = ROOT . DS . 'tests/test_app/TestApp/Model/Filter/';
+
+        $this->_in = $this->getMockBuilder(ConsoleInput::class)->getMock();
+
+        $files = (new Folder($this->_generatedBasePath))->findRecursive();
+        foreach ($files as $file) {
+            unlink($file);
+        }
+
+        $this->useCommandRunner();
+    }
+
+    /**
+     * Test empty migration.
+     *
+     * @return void
+     */
+    public function testEmpty()
+    {
+        $this->exec('bake filter_collection Empty');
+
+        $this->assertExitCode(BaseCommand::CODE_SUCCESS);
+
+        $file = $this->_generatedBasePath . 'EmptyFilterCollection.php';
+        $result = file_get_contents($file);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDefault()
+    {
+        $this->exec('bake filter_collection Posts');
+
+        $this->assertExitCode(BaseCommand::CODE_SUCCESS);
+
+        $file = $this->_generatedBasePath . 'PostsFilterCollection.php';
+        $result = file_get_contents($file);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testCustomName()
+    {
+        $this->exec('bake filter_collection MyPosts Posts');
+
+        $this->assertExitCode(BaseCommand::CODE_SUCCESS);
+
+        $file = $this->_generatedBasePath . 'MyPostsFilterCollection.php';
+        $result = file_get_contents($file);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testPrefix()
+    {
+        $this->exec('bake filter_collection PrefixedPosts Posts --prefix Admin');
+
+        $this->assertExitCode(BaseCommand::CODE_SUCCESS);
+
+        $file = $this->_generatedBasePath . 'Admin/PrefixedPostsFilterCollection.php';
+        $result = file_get_contents($file);
+        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,4 +31,8 @@ if (file_exists($root . '/config/bootstrap.php')) {
 
 require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
 
+if (!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
+}
+
 \Cake\Core\Configure::write('App.namespace', 'Search\Test\TestApp');

--- a/tests/comparisons/Filter/testCustomName.php
+++ b/tests/comparisons/Filter/testCustomName.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Search\Test\TestApp\Model\Filter;
+
+use Search\Model\Filter\FilterCollection;
+
+class MyPostsFilterCollection extends FilterCollection
+{
+    /**
+     * @return void
+     */
+    public function initialize(): void
+    {
+        $this->value('author_id');
+        $this->like('title');
+        $this->like('published');
+    }
+}

--- a/tests/comparisons/Filter/testDefault.php
+++ b/tests/comparisons/Filter/testDefault.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Search\Test\TestApp\Model\Filter;
+
+use Search\Model\Filter\FilterCollection;
+
+class PostsFilterCollection extends FilterCollection
+{
+    /**
+     * @return void
+     */
+    public function initialize(): void
+    {
+        $this->value('author_id');
+        $this->like('title');
+        $this->like('published');
+    }
+}

--- a/tests/comparisons/Filter/testEmpty.php
+++ b/tests/comparisons/Filter/testEmpty.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Search\Test\TestApp\Model\Filter;
+
+use Search\Model\Filter\FilterCollection;
+
+class EmptyFilterCollection extends FilterCollection
+{
+    /**
+     * @return void
+     */
+    public function initialize(): void
+    {
+    }
+}

--- a/tests/comparisons/Filter/testPrefix.php
+++ b/tests/comparisons/Filter/testPrefix.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Search\Test\TestApp\Model\Filter\Admin;
+
+use Search\Model\Filter\FilterCollection;
+
+class PrefixedPostsFilterCollection extends FilterCollection
+{
+    /**
+     * @return void
+     */
+    public function initialize(): void
+    {
+        $this->value('author_id');
+        $this->like('title');
+        $this->like('published');
+    }
+}


### PR DESCRIPTION
I whipped sth up
Resolves https://github.com/FriendsOfCake/search/issues/296

I didn't check the visibility on the entity yet, if I should do that let me know
But this already works quite well for default cases IMO.

- Model handling if not matching the collection name
- Prefix handling

We could think about further improvements as follow up:
- No argument => ask [y/n] to bake each existing model of that namespace into the same name of collection

