### PR TITLE
Allow not filter for value instead of long array list.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -437,6 +437,11 @@ Set it to an empty string there to check via `=`/`!=` instead of `IS NULL`/`IS N
 - `mode` (`string`, defaults to `OR`) The conditional mode to use when matching
   against multiple fields. Valid values are `OR` and `AND`.
 
+- `not` (`string`, defaults to `null`) An alternative to `multiValue`, especially if you have
+ a lot of values. The filter accepts any string, but it should ideally be a single and unique char
+ as prefix. E.g. `!` for string values or `-` for numeric values.
+ If enabled, the filter will invert the expression for this value.
+
 #### `Finder`
 
 - `finder` (`string`) The [find type](https://book.cakephp.org/4/en/orm/retrieving-data-and-resultsets.html#custom-finder-methods) to use.

--- a/docs/README.md
+++ b/docs/README.md
@@ -437,10 +437,10 @@ Set it to an empty string there to check via `=`/`!=` instead of `IS NULL`/`IS N
 - `mode` (`string`, defaults to `OR`) The conditional mode to use when matching
   against multiple fields. Valid values are `OR` and `AND`.
 
-- `not` (`string`, defaults to `null`) An alternative to `multiValue`, especially if you have
+- `negationChar` (`string`, defaults to `null`) An alternative to `multiValue`, especially if you have
  a lot of values. The filter accepts any string, but it should ideally be a single and unique char
- as prefix. E.g. `!` for string values or `-` for numeric values.
- If enabled, the filter will invert the expression for this value.
+ as prefix for your search value. E.g. `!` for string values or `-` for numeric values.
+ If enabled, the filter will negate the expression for this value.
 
 #### `Finder`
 

--- a/src/Model/Filter/Value.php
+++ b/src/Model/Filter/Value.php
@@ -16,7 +16,7 @@ class Value extends Base
      */
     protected $_defaultConfig = [
         'mode' => 'OR',
-        'not' => null,
+        'negationChar' => null,
     ];
 
     /**
@@ -40,13 +40,13 @@ class Value extends Base
         }
 
         $isNot = false;
-        if ($this->getConfig('not')) {
+        if ($this->getConfig('negationChar')) {
             if ($this->getConfig('multiValue')) {
                 throw new Exception('Cannot use NOT functionality with multi value');
             }
 
-            if (strpos($value, $this->getConfig('not')) === 0) {
-                $value = mb_substr($value, strlen($this->getConfig('not')));
+            if (strpos($value, $this->getConfig('negationChar')) === 0) {
+                $value = mb_substr($value, strlen($this->getConfig('negationChar')));
                 $isNot = true;
             }
         }

--- a/src/Model/Filter/Value.php
+++ b/src/Model/Filter/Value.php
@@ -39,15 +39,15 @@ class Value extends Base
             return false;
         }
 
-        $isNot = false;
+        $isNegated = false;
         if ($this->getConfig('negationChar')) {
             if ($this->getConfig('multiValue')) {
                 throw new Exception('Cannot use NOT functionality with multi value');
             }
 
             if (strpos($value, $this->getConfig('negationChar')) === 0) {
-                $value = mb_substr($value, strlen($this->getConfig('negationChar')));
-                $isNot = true;
+                $value = mb_substr($value, mb_strlen($this->getConfig('negationChar')));
+                $isNegated = true;
             }
         }
 
@@ -63,12 +63,12 @@ class Value extends Base
 
         $expressions = [];
         foreach ($this->fields() as $field) {
-            $expressions[] = function (QueryExpression $e) use ($field, $value, $isMultiValue, $isNot) {
+            $expressions[] = function (QueryExpression $e) use ($field, $value, $isMultiValue, $isNegated) {
                 if ($isMultiValue) {
                     return $e->in($field, $value);
                 }
 
-                if ($isNot) {
+                if ($isNegated) {
                     return $e->notEq($field, $value);
                 }
 

--- a/tests/TestCase/Model/Filter/ValueTest.php
+++ b/tests/TestCase/Model/Filter/ValueTest.php
@@ -312,4 +312,28 @@ class ValueTest extends TestCase
             Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
         );
     }
+
+    /**
+     * @return void
+     */
+    public function testProcessNot()
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Value('number', $manager, [
+            'not' => '!',
+        ]);
+        $filter->setArgs(['number' => '!3']);
+        $filter->setQuery($articles->find());
+        $filter->process();
+
+        $this->assertRegExp(
+            '/WHERE Articles\.number != :c0$/',
+            $filter->getQuery()->sql()
+        );
+        $this->assertEquals(
+            ['3'],
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+        );
+    }
 }

--- a/tests/TestCase/Model/Filter/ValueTest.php
+++ b/tests/TestCase/Model/Filter/ValueTest.php
@@ -316,12 +316,12 @@ class ValueTest extends TestCase
     /**
      * @return void
      */
-    public function testProcessNot()
+    public function testProcessNegation()
     {
         $articles = $this->getTableLocator()->get('Articles');
         $manager = new Manager($articles);
         $filter = new Value('number', $manager, [
-            'not' => '!',
+            'negationChar' => '!',
         ]);
         $filter->setArgs(['number' => '!3']);
         $filter->setQuery($articles->find());


### PR DESCRIPTION
The multiValue part is nice, but once you have too many values, the URL gets out of hand.

    ?functional_type=0,1,2,8,10,3,7,5,4,6,11,...........&...

For this I propose the "not" config instead.
Works fine for us locally.

    ?functional_type=!9&...

Does this sound good?

Fully BC.

Constraints: This is disabled to work together with multiValue as it is designed as alternative config.
If someone has ideas how to combine them, that could be a future PR maybe?