### PR TITLE
Fix error when bake plugin is not loaded.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "cakephp/twig-view": "^1.1.1",
-        "cakephp/bake": "^2.2.0",
+        "cakephp/bake": "^2.3",
         "phpunit/phpunit": "~8.5.0",
         "cakephp/cakephp-codesniffer": "^4.0",
         "muffin/webservice": "^3.0@beta"

--- a/src/Command/Bake/FilterCollectionCommand.php
+++ b/src/Command/Bake/FilterCollectionCommand.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Search\Command;
+namespace Search\Command\Bake;
 
 use Bake\Command\BakeCommand;
 use Bake\Utility\TemplateRenderer;
@@ -19,7 +19,7 @@ use Cake\ORM\Table;
  * src/Model/Filter/MyCustomFilterCollection.php
  * src/Model/Filter/Admin/UsersFilterCollection.php
  */
-class BakeFilterCollectionCommand extends BakeCommand
+class FilterCollectionCommand extends BakeCommand
 {
     /**
      * Task name used in path generation.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Search;
 
+use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
 
 class Plugin extends BasePlugin
@@ -27,4 +28,17 @@ class Plugin extends BasePlugin
      * @var bool
      */
     protected $routesEnabled = false;
+
+    /**
+     * Add console commands for the plugin.
+     *
+     * @param \Cake\Console\CommandCollection $commands The command collection to update
+     * @return \Cake\Console\CommandCollection
+     */
+    public function console(CommandCollection $commands): CommandCollection
+    {
+        // Bake plugin handles discovery of bake commands itself.
+        // Since we currently only have a command class for bake command, we don't need to to anything here.
+        return $commands;
+    }
 }

--- a/tests/TestCase/Command/Bake/FilterCollectionCommandTest.php
+++ b/tests/TestCase/Command/Bake/FilterCollectionCommandTest.php
@@ -1,17 +1,20 @@
 <?php
 declare(strict_types=1);
 
-namespace Search\Test\TestCase\Command;
+namespace Search\Test\TestCase\Command\Bake;
 
 use Cake\Console\BaseCommand;
+use Cake\Console\CommandCollection;
 use Cake\Console\ConsoleInput;
 use Cake\Core\Plugin;
-use Cake\Filesystem\Folder;
+use Cake\Event\EventManager;
+use Cake\Filesystem\Filesystem;
 use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\StringCompareTrait;
 use Cake\TestSuite\TestCase;
+use Search\Command\Bake\FilterCollectionCommand;
 
-class BakeFilterCollectionCommandTest extends TestCase
+class FilterCollectionCommandTest extends TestCase
 {
     use StringCompareTrait;
     use ConsoleIntegrationTestTrait;
@@ -41,12 +44,17 @@ class BakeFilterCollectionCommandTest extends TestCase
 
         $this->_in = $this->getMockBuilder(ConsoleInput::class)->getMock();
 
-        $files = (new Folder($this->_generatedBasePath))->findRecursive();
-        foreach ($files as $file) {
-            unlink($file);
-        }
+        $fs = new Filesystem();
+        $fs->deleteDir($this->_generatedBasePath);
 
         $this->useCommandRunner();
+
+        EventManager::instance()->on(
+            'Console.buildCommands',
+            function ($event, CommandCollection $commands) {
+                $commands->add(FilterCollectionCommand::defaultName(), FilterCollectionCommand::class);
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
Closes #305.

While this fixes the issue, until https://github.com/cakephp/bake/pull/727 is merged the command will show up as `bake_filter_collection` instead of `filter_collection`. I don't think that's a biggie as it's a dev tool only.