### PR TITLE
Fix return value for Boolean.

### DIFF
--- a/src/Model/Filter/Boolean.php
+++ b/src/Model/Filter/Boolean.php
@@ -41,25 +41,25 @@ class Boolean extends Base
             $bool = false;
         }
 
-        if ($bool !== null) {
-            if (!$this->manager()->getRepository() instanceof Table) {
-                foreach ($this->fields() as $field) {
-                    $this->getQuery()->where([
-                        $field => $bool,
-                    ]);
-                }
+        if ($bool === null) {
+            return false;
+        }
 
-                return true;
-            }
-
+        if ($this->manager()->getRepository() instanceof Table) {
             $conditions = [];
             foreach ($this->fields() as $field) {
                 $conditions[] = [$field => $bool];
             }
 
             $this->getQuery()->andWhere([$this->getConfig('mode') => $conditions]);
+        } else {
+            foreach ($this->fields() as $field) {
+                $this->getQuery()->where([
+                    $field => $bool,
+                ]);
+            }
         }
 
-        return false;
+        return true;
     }
 }

--- a/tests/TestCase/Model/Filter/BooleanTest.php
+++ b/tests/TestCase/Model/Filter/BooleanTest.php
@@ -29,8 +29,9 @@ class BooleanTest extends TestCase
         $filter = new Boolean('is_active', $manager);
         $filter->setArgs(['is_active' => 'on']);
         $filter->setQuery($articles->find());
-        $filter->process();
+        $processed = $filter->process();
 
+        $this->assertTrue($processed);
         $this->assertRegExp(
             '/WHERE Articles\.is_active = \:c0$/',
             $filter->getQuery()->sql()
@@ -51,8 +52,9 @@ class BooleanTest extends TestCase
         $filter = new Boolean('is_active', $manager);
         $filter->setArgs(['is_active' => 'off']);
         $filter->setQuery($articles->find());
-        $filter->process();
+        $processed = $filter->process();
 
+        $this->assertTrue($processed);
         $this->assertRegExp(
             '/WHERE Articles\.is_active = \:c0$/',
             $filter->getQuery()->sql()
@@ -246,8 +248,9 @@ class BooleanTest extends TestCase
         $filter = new Boolean('is_active', $manager);
         $filter->setArgs(['is_active' => 'neitherTruthyNorFalsy']);
         $filter->setQuery($articles->find());
-        $filter->process();
+        $processed = $filter->process();
 
+        $this->assertFalse($processed);
         $this->assertEmpty($filter->getQuery()->clause('where'));
         $filter->getQuery()->sql();
         $this->assertEmpty($filter->getQuery()->getValueBinder()->bindings());


### PR DESCRIPTION
The process method of the Boolean filter can return false even if the filter was actually applied. Which results i.E. in SearchHelper::isSearch() returning a wrong value. This should fix that issue.