### PR TITLE
Use comparison expression

### DIFF
--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -81,9 +81,7 @@ abstract class Base
 
         if (
             empty($config['fields']) ||
-            (!array_filter($config['fields'], function ($value) {
-                return strlen($value) > 0;
-            }))
+            (!array_filter($config['fields']))
         ) {
             throw new \InvalidArgumentException(
                 'The `field` option is invalid. Expected a non-empty string or array.'
@@ -128,12 +126,12 @@ abstract class Base
             return $field;
         }
 
-        $return = [];
-        foreach ($field as $fld) {
-            $return[] = $repository->aliasField($fld);
-        }
-
-        return $return;
+        return array_map(
+            function ($field) use ($repository) {
+                return is_string($field) ? $repository->aliasField($field) : $field;
+            },
+            $field
+        );
     }
 
     /**

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -81,7 +81,9 @@ abstract class Base
 
         if (
             empty($config['fields']) ||
-            (!array_filter($config['fields']))
+            (!array_filter($config['fields'], function ($value) {
+                return !empty($value) || (is_string($value) && strlen($value) > 0);
+            }))
         ) {
             throw new \InvalidArgumentException(
                 'The `field` option is invalid. Expected a non-empty string or array.'

--- a/src/Model/Filter/Boolean.php
+++ b/src/Model/Filter/Boolean.php
@@ -46,21 +46,15 @@ class Boolean extends Base
             return false;
         }
 
-        if ($this->manager()->getRepository() instanceof Table) {
-            $conditions = [];
-            foreach ($this->fields() as $field) {
-                $conditions[] = new ComparisonExpression($field, $bool, 'boolean', '=');
-            }
-
-            $this->getQuery()->andWhere([$this->getConfig('mode') => $conditions]);
-
-            return true;
+        $conditions = [];
+        foreach ($this->fields() as $field) {
+            $conditions[] = new ComparisonExpression($field, $bool, 'boolean', '=');
         }
 
-        foreach ($this->fields() as $field) {
-            $this->getQuery()->where([
-                new ComparisonExpression($field, $bool, 'boolean', '='),
-            ]);
+        if ($this->manager()->getRepository() instanceof Table) {
+            $this->getQuery()->andWhere([$this->getConfig('mode') => $conditions]);
+        } else {
+            $this->getQuery()->where($conditions);
         }
 
         return true;

--- a/src/Model/Filter/Boolean.php
+++ b/src/Model/Filter/Boolean.php
@@ -59,7 +59,7 @@ class Boolean extends Base
 
         foreach ($this->fields() as $field) {
             $this->getQuery()->where([
-                new ComparisonExpression($field, $bool, 'boolean', '=')
+                new ComparisonExpression($field, $bool, 'boolean', '='),
             ]);
         }
 

--- a/src/Model/Filter/Boolean.php
+++ b/src/Model/Filter/Boolean.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Search\Model\Filter;
 
+use Cake\Database\Expression\ComparisonExpression;
 use Cake\ORM\Table;
 
 class Boolean extends Base
@@ -48,7 +49,7 @@ class Boolean extends Base
         if ($this->manager()->getRepository() instanceof Table) {
             $conditions = [];
             foreach ($this->fields() as $field) {
-                $conditions[] = [$field => $bool];
+                $conditions[] = new ComparisonExpression($field, $bool, 'boolean', '=');
             }
 
             $this->getQuery()->andWhere([$this->getConfig('mode') => $conditions]);
@@ -58,7 +59,7 @@ class Boolean extends Base
 
         foreach ($this->fields() as $field) {
             $this->getQuery()->where([
-                $field => $bool,
+                new ComparisonExpression($field, $bool, 'boolean', '=')
             ]);
         }
 

--- a/src/Model/Filter/Compare.php
+++ b/src/Model/Filter/Compare.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Search\Model\Filter;
 
+use Cake\Database\Expression\ComparisonExpression;
 use InvalidArgumentException;
 
 class Compare extends Base
@@ -48,8 +49,7 @@ class Compare extends Base
         }
 
         foreach ($this->fields() as $field) {
-            $left = $field . ' ' . $this->getConfig('operator');
-            $conditions[] = [$left => $value];
+            $conditions[] = new ComparisonExpression($field, $value, 'string', $this->getConfig('operator'));
         }
 
         $this->getQuery()->andWhere([$this->getConfig('mode') => $conditions]);

--- a/src/Model/Filter/Exists.php
+++ b/src/Model/Filter/Exists.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Search\Model\Filter;
 
+use Cake\Database\Expression\ComparisonExpression;
 use Cake\ORM\Table;
 
 class Exists extends Base
@@ -46,7 +47,7 @@ class Exists extends Base
         if (!$this->manager()->getRepository() instanceof Table) {
             foreach ($this->fields() as $field) {
                 $this->getQuery()->where([
-                    $field . $comparison => $nullValue,
+                    new ComparisonExpression($field, $nullValue, 'string', $comparison),
                 ]);
             }
 
@@ -55,7 +56,9 @@ class Exists extends Base
 
         $conditions = [];
         foreach ($this->fields() as $field) {
-            $conditions[] = [$field . $comparison => $nullValue];
+            $conditions[] = [
+                new ComparisonExpression($field, $nullValue, 'string', $comparison),
+            ];
         }
 
         $this->getQuery()->andWhere([$this->getConfig('mode') => $conditions]);

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Search\Model\Filter;
 
 use Cake\Core\App;
+use Cake\Database\Expression\ComparisonExpression;
 use Cake\ORM\Query;
 use InvalidArgumentException;
 use RuntimeException;
@@ -49,13 +50,12 @@ class Like extends Base
 
         $conditions = [];
         foreach ($this->fields() as $field) {
-            $left = $field . ' ' . $comparison;
             if ($isMultiValue) {
                 $valueConditions = [];
                 foreach ($value as $val) {
                     $right = $this->_wildcards($val);
                     if ($right !== false) {
-                        $valueConditions[] = [$left => $right];
+                        $valueConditions[] = new ComparisonExpression($field, $right, 'string', $comparison);
                     }
                 }
                 if (!empty($valueConditions)) {
@@ -64,7 +64,7 @@ class Like extends Base
             } else {
                 $right = $this->_wildcards($value);
                 if ($right !== false) {
-                    $conditions[] = [$left => $right];
+                    $conditions = new ComparisonExpression($field, $right, 'string', $comparison);
                 }
             }
         }

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -64,7 +64,7 @@ class Like extends Base
             } else {
                 $right = $this->_wildcards($value);
                 if ($right !== false) {
-                    $conditions = new ComparisonExpression($field, $right, 'string', $comparison);
+                    $conditions[] = new ComparisonExpression($field, $right, 'string', $comparison);
                 }
             }
         }

--- a/src/Model/Filter/Value.php
+++ b/src/Model/Filter/Value.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Search\Model\Filter;
 
 use Cake\Core\Exception\Exception;
+use Cake\Database\Expression\ComparisonExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Table;
 
@@ -55,7 +56,7 @@ class Value extends Base
         if (!$this->manager()->getRepository() instanceof Table) {
             foreach ($this->fields() as $field) {
                 $this->getQuery()->where([
-                    $field => $value,
+                    new ComparisonExpression($field, $value, 'string', $isNegated ? '!=' : '='),
                 ]);
             }
 

--- a/tests/TestCase/Model/Filter/LikeTest.php
+++ b/tests/TestCase/Model/Filter/LikeTest.php
@@ -33,7 +33,7 @@ class LikeTest extends TestCase
         $filter->process();
 
         $this->assertRegExp(
-            '/WHERE Articles\.title like \:c0$/',
+            '/WHERE Articles\.title LIKE \:c0$/',
             $filter->getQuery()->sql()
         );
         $this->assertEquals(
@@ -46,7 +46,7 @@ class LikeTest extends TestCase
         $filter->process();
 
         $this->assertRegExp(
-            '/WHERE Articles\.title ilike \:c0$/',
+            '/WHERE Articles\.title ILIKE \:c0$/',
             $filter->getQuery()->sql()
         );
         $this->assertEquals(
@@ -68,7 +68,7 @@ class LikeTest extends TestCase
         $filter->process();
 
         $this->assertRegExp(
-            '/WHERE Articles\.title like :c0$/',
+            '/WHERE Articles\.title LIKE :c0$/',
             $filter->getQuery()->sql()
         );
         $this->assertEquals(
@@ -93,7 +93,7 @@ class LikeTest extends TestCase
         $filter->process();
 
         $this->assertRegExp(
-            '/WHERE \(Articles\.title like :c0 OR Articles\.other like :c1\)$/',
+            '/WHERE \(Articles\.title LIKE :c0 OR Articles\.other LIKE :c1\)$/',
             $filter->getQuery()->sql()
         );
         $this->assertEquals(
@@ -115,7 +115,7 @@ class LikeTest extends TestCase
         $filter->process();
 
         $this->assertRegExp(
-            '/WHERE \(Articles\.title like :c0 OR Articles\.title like :c1\)$/',
+            '/WHERE \(Articles\.title LIKE :c0 OR Articles\.title LIKE :c1\)$/',
             $filter->getQuery()->sql()
         );
         $this->assertEquals(
@@ -140,7 +140,7 @@ class LikeTest extends TestCase
         $filter->process();
 
         $this->assertRegExp(
-            '/WHERE \(Articles\.title like :c0 AND Articles\.title like :c1\)$/',
+            '/WHERE \(Articles\.title LIKE :c0 AND Articles\.title LIKE :c1\)$/',
             $filter->getQuery()->sql()
         );
         $this->assertEquals(
@@ -165,8 +165,8 @@ class LikeTest extends TestCase
         $filter->process();
 
         $this->assertRegExp(
-            '/WHERE \(\(Articles\.title like :c0 OR Articles\.title like :c1\) ' .
-                'OR \(Articles\.other like :c2 OR Articles\.other like :c3\)\)$/',
+            '/WHERE \(\(Articles\.title LIKE :c0 OR Articles\.title LIKE :c1\) ' .
+                'OR \(Articles\.other LIKE :c2 OR Articles\.other LIKE :c3\)\)$/',
             $filter->getQuery()->sql()
         );
         $this->assertEquals(
@@ -192,8 +192,8 @@ class LikeTest extends TestCase
         $filter->process();
 
         $this->assertRegExp(
-            '/WHERE \(\(Articles\.title like :c0 OR Articles\.title like :c1\) ' .
-                'AND \(Articles\.other like :c2 OR Articles\.other like :c3\)\)$/',
+            '/WHERE \(\(Articles\.title LIKE :c0 OR Articles\.title LIKE :c1\) ' .
+                'AND \(Articles\.other LIKE :c2 OR Articles\.other LIKE :c3\)\)$/',
             $filter->getQuery()->sql()
         );
         $this->assertEquals(
@@ -278,7 +278,7 @@ class LikeTest extends TestCase
         $filter->process();
 
         $this->assertRegExp(
-            '/WHERE Articles\.title like :c0$/',
+            '/WHERE Articles\.title LIKE :c0$/',
             $filter->getQuery()->sql()
         );
         $this->assertEquals(

--- a/tests/TestCase/Model/SearchTraitTest.php
+++ b/tests/TestCase/Model/SearchTraitTest.php
@@ -71,10 +71,10 @@ class SearchTraitTest extends TestCase
         $this->assertFalse($this->Articles->isSearch());
 
         $query = $this->Articles->find('search', ['search' => $queryString]);
-        $this->assertSame([
-            'Articles.foo' => 'a',
-            'Articles.public' => false,
-        ], $query->where());
+        $this->assertSame('Articles.foo', $query->where()[0]->getField());
+        $this->assertSame('a', $query->where()[0]->getValue());
+        $this->assertSame('Articles.public', $query->where()[1]->getField());
+        $this->assertSame(false, $query->where()[1]->getValue());
         $this->assertTrue($this->Articles->isSearch());
     }
 


### PR DESCRIPTION
This PR proposes a refactor of the conditions generated by filters and enables passing fields as expressions.

## Motivations

Right now, filters use strings concatenation to build conditions. This assumes that all input values are string. The `ComparisonExpression` constructor is more versatile, since it also accepts expressions and reduces the parsing overhead of the ORM.

Furthermore, using expressions for fields enables more controlled customisation. For example, we need to perform a case insensitive search in a JSON field. Using expression, we can use `COLLATE` (we have a strongly dependency on mysql) to cast the field to the required encoding:

```php
$this->searchManager()->add('q', 'Search.Like', [
    'before' => true,
    'after' => true,
    'fieldMode' => 'OR',
    'comparison' => 'LIKE',
    'wildcardAny' => '*',
    'wildcardOne' => '?',
    'fields' => [
        new ComparisonExpression('body', 'utf8mb4_general_ci', 'string', 'COLLATE'),
    ],
    'colType' => ['body' => 'string'],
]);
```
