### PR TITLE
More clear feedback on typo in model class setup.

### DIFF
--- a/src/Controller/Component/SearchComponent.php
+++ b/src/Controller/Component/SearchComponent.php
@@ -108,6 +108,12 @@ class SearchComponent extends Component
         }
 
         if (!$model->behaviors()->has('Search')) {
+            if ($this->getConfig('modelClass')) {
+                throw new UnexpectedValueException(
+                    sprintf('Configured modelClass `%s not found`', $this->getConfig('modelClass'))
+                );
+            }
+
             return;
         }
 


### PR DESCRIPTION
I had a typo in the model class `BitmaskedRecords` and things appeared to work fine, even though the model was never loaded.

```
		$this->loadComponent('Search.Search', [
			'actions' => ['bitmaskSearch'],
			'queryStringWhitelist' => ['type'],
			'modelClass' => 'Sandbox.BitmaskedRecords',
		]);
```
and I didnt notice that things are wrong, only when looking closer to the reason why the reset button would not show.
With this info it should be clear that a configured value would need to exist or should otherwise be left null/empty.