### PR TITLE
multiValueExactMatching feature

### DIFF
--- a/docs/filters-and-examples.md
+++ b/docs/filters-and-examples.md
@@ -162,6 +162,10 @@ The following options are supported by all filters except `Callback` and `Finder
   auto-tokenize multiple values using a specific separator string. If disabled, the data
   must be an in form of an array.
 
+- `multiValueExactMatching` (`bool|string`, defaults to `false`) If enabled, this will match
+  phrases using a matching character (defaults to `"`). You can also define one yourself.
+  Note: This only works for `multiValueSeparator` set to a single space as character.
+
 - `field` (`string|array`), defaults to the name passed to the first argument of the
   add filter method) The name of the field to use for searching. Works like the base
   `field` option but also accepts multiple field names as an array. When defining

--- a/src/Command/Bake/FilterCollectionCommand.php
+++ b/src/Command/Bake/FilterCollectionCommand.php
@@ -217,7 +217,7 @@ class FilterCollectionCommand extends BakeCommand
         $parser = $this->_setCommonOptions($parser);
 
         $parser->setDescription(
-            'Bake filter collections for a model search functionality.'
+            'Bake filter collections for a model search functionality.',
         )->addArgument('name', [
             'help' => 'Name of the filter collection to bake. You can use Plugin.name '
             . 'as a shortcut for plugin baking. By default this will also try to find the model based on that name.',

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -116,7 +116,7 @@ class Manager
         if (!$className) {
             throw new InvalidArgumentException(sprintf(
                 'The collection class "%sCollection" does not exist',
-                $class
+                $class,
             ));
         }
 
@@ -125,7 +125,7 @@ class Manager
             throw new InvalidArgumentException(sprintf(
                 'The collection must be instance of FilterCollectionInterface. ' .
                 'Got instance of "%s" instead',
-                get_class($instance)
+                get_class($instance),
             ));
         }
 

--- a/src/Model/Behavior/SearchBehavior.php
+++ b/src/Model/Behavior/SearchBehavior.php
@@ -62,7 +62,7 @@ class SearchBehavior extends Behavior
         $defaultCollectionClass = sprintf(
             '%s\Model\Filter\%sCollection',
             Configure::read('App.namespace'),
-            $this->table()->getAlias()
+            $this->table()->getAlias(),
         );
         if (class_exists($defaultCollectionClass)) {
             /**

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -238,9 +238,10 @@ abstract class Base
 
         $terms = [];
 
+        $escapedQuoteChar = preg_quote($quoteChar, '/');
         // Match quoted phrases and unquoted words
         preg_match_all(
-            '/' . preg_quote($quoteChar) . '([^' . preg_quote($quoteChar) . ']+)' . preg_quote($quoteChar) . '|\S+/',
+            '/' . $escapedQuoteChar . '([^' . $escapedQuoteChar . ']+)' . $escapedQuoteChar . '|\S+/',
             $input,
             $matches,
         );

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -76,7 +76,7 @@ abstract class Base
 
         if (isset($config['field'])) {
             throw new InvalidArgumentException(
-                'The `field` option has been renamed to `fields`.'
+                'The `field` option has been renamed to `fields`.',
             );
         }
         $config['fields'] = (array)$config['fields'];
@@ -89,7 +89,7 @@ abstract class Base
             }))
         ) {
             throw new InvalidArgumentException(
-                'The `field` option is invalid. Expected a non-empty string or array.'
+                'The `field` option is invalid. Expected a non-empty string or array.',
             );
         }
 
@@ -99,7 +99,7 @@ abstract class Base
             $config['name'] !== '0')
         ) {
             throw new InvalidArgumentException(
-                'The `$name` argument is invalid. Expected a non-empty string.'
+                'The `$name` argument is invalid. Expected a non-empty string.',
             );
         }
     }
@@ -227,7 +227,7 @@ abstract class Base
     {
         if ($this->getConfig('multiValueSeparator') !== ' ') {
             throw new UnexpectedValueException(
-                'The `multiValueSeparator` option must be a single space when `multiValueExactMatching` is used.'
+                'The `multiValueSeparator` option must be a single space when `multiValueExactMatching` is used.',
             );
         }
 
@@ -239,10 +239,14 @@ abstract class Base
         $terms = [];
 
         // Match quoted phrases and unquoted words
-        preg_match_all('/' . preg_quote($quoteChar) . '([^' . preg_quote($quoteChar) . ']+)' . preg_quote($quoteChar) . '|\S+/', $input, $matches);
+        preg_match_all(
+            '/' . preg_quote($quoteChar) . '([^' . preg_quote($quoteChar) . ']+)' . preg_quote($quoteChar) . '|\S+/',
+            $input,
+            $matches,
+        );
 
         foreach ($matches[0] as $match) {
-            // If it’s quoted, strip the quotes
+            // If it's quoted, strip the quotes
             if ($match[0] === $quoteChar) {
                 $terms[] = trim($match, $quoteChar);
             } else {

--- a/src/Model/Filter/Callback.php
+++ b/src/Model/Filter/Callback.php
@@ -16,7 +16,7 @@ class Callback extends Base
             $this->getConfig('callback'),
             $this->getQuery(),
             $this->getArgs(),
-            $this
+            $this,
         ) ?? true;
     }
 }

--- a/src/Model/Filter/Compare.php
+++ b/src/Model/Filter/Compare.php
@@ -38,7 +38,7 @@ class Compare extends Base
         if (!in_array($this->getConfig('operator'), $this->_operators, true)) {
             throw new InvalidArgumentException(sprintf(
                 'The operator %s is invalid!',
-                $this->getConfig('operator')
+                $this->getConfig('operator'),
             ));
         }
 

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -159,7 +159,7 @@ class Like extends Base
             $query = $this->getQuery();
             if (!$query instanceof SelectQuery) {
                 throw new RuntimeException(
-                    '$query must be instance of Cake\ORM\Query\SelectQuery to be able to check driver name.'
+                    '$query must be instance of Cake\ORM\Query\SelectQuery to be able to check driver name.',
                 );
             }
 
@@ -178,7 +178,7 @@ class Like extends Base
         if ($className === null) {
             throw new InvalidArgumentException(sprintf(
                 'Escape driver "%s" in like filter was not found.',
-                $class
+                $class,
             ));
         }
 

--- a/src/Model/SearchTrait.php
+++ b/src/Model/SearchTrait.php
@@ -50,7 +50,7 @@ trait SearchTrait
     public function findSearch(
         QueryInterface $query,
         array $search,
-        string $collection = Manager::DEFAULT_COLLECTION
+        string $collection = Manager::DEFAULT_COLLECTION,
     ): QueryInterface {
         $filters = $this->_getFilters($collection);
 
@@ -62,7 +62,7 @@ trait SearchTrait
         $this->_isSearch = $this->processor()->process(
             $filters,
             $query,
-            $search
+            $search,
         );
 
         return $query;
@@ -108,7 +108,7 @@ trait SearchTrait
     {
         return $this->_manager ??= new Manager(
             $this->_repository(),
-            $this->_collectionClass
+            $this->_collectionClass,
         );
     }
 

--- a/tests/TestCase/Command/Bake/FilterCollectionCommandTest.php
+++ b/tests/TestCase/Command/Bake/FilterCollectionCommandTest.php
@@ -42,7 +42,7 @@ class FilterCollectionCommandTest extends TestCase
             'Console.buildCommands',
             function ($event, CommandCollection $commands) {
                 $commands->add(FilterCollectionCommand::defaultName(), FilterCollectionCommand::class);
-            }
+            },
         );
 
         $this->loadPlugins(['Search']);

--- a/tests/TestCase/Controller/Component/SearchComponentTest.php
+++ b/tests/TestCase/Controller/Component/SearchComponentTest.php
@@ -33,7 +33,7 @@ class SearchComponentTest extends TestCase
             $routes->connect(
                 '/users/my-predictions',
                 ['controller' => 'UserAnswers', 'action' => 'index', 'type' => 'open'],
-                ['pass' => ['type'], '_name' => 'userOpenPredictions']
+                ['pass' => ['type'], '_name' => 'userOpenPredictions'],
             );
             $routes->fallbacks();
         });
@@ -244,7 +244,7 @@ class SearchComponentTest extends TestCase
             $this->Controller->getRequest()->withAttribute('params', [
                 'controller' => 'Articles',
                 'action' => 'index',
-            ])
+            ]),
         );
 
         if (method_exists($this->Controller, 'fetchTable')) {
@@ -272,7 +272,7 @@ class SearchComponentTest extends TestCase
             $this->Controller->getRequest()->withAttribute('params', [
                 'controller' => 'Articles',
                 'action' => 'index',
-            ])
+            ]),
         );
 
         $articles = $this->getMockBuilder(Table::class)->addMethods(['isSearch'])->getMock();

--- a/tests/TestCase/ManagerTest.php
+++ b/tests/TestCase/ManagerTest.php
@@ -252,7 +252,7 @@ class ManagerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf(
             'The collection must be instance of FilterCollectionInterface. Got instance of "%s" instead',
-            Configure::class
+            Configure::class,
         ));
         $manager->getFilters();
     }

--- a/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
@@ -203,7 +203,7 @@ class SearchBehaviorTest extends TestCase
                 'foo' => '0',
                 'search' => 'b',
                 'page' => '1',
-            ]
+            ],
         );
         $this->assertEquals(2, $query->clause('where')->count());
         $this->assertTrue($this->Articles->isSearch());

--- a/tests/TestCase/Model/Filter/BaseTest.php
+++ b/tests/TestCase/Model/Filter/BaseTest.php
@@ -220,10 +220,14 @@ class BaseTest extends TestCase
         $filter->setArgs(['fields' => 'value1 "value2 and 3" value4']);
         $this->assertEquals(['value1', 'value2 and 3', 'value4'], $filter->value());
 
-        $filter->setConfig('multiValueSeparator', ' ');
         $filter->setConfig('multiValueExactMatching', '*');
 
         $filter->setArgs(['fields' => 'value1 *value2 and 3* value4']);
+        $this->assertEquals(['value1', 'value2 and 3', 'value4'], $filter->value());
+
+        $filter->setConfig('multiValueExactMatching', '/');
+
+        $filter->setArgs(['fields' => 'value1 /value2 and 3/ value4']);
         $this->assertEquals(['value1', 'value2 and 3', 'value4'], $filter->value());
     }
 

--- a/tests/TestCase/Model/Filter/BaseTest.php
+++ b/tests/TestCase/Model/Filter/BaseTest.php
@@ -54,7 +54,7 @@ class BaseTest extends TestCase
         new TestFilter(
             'name',
             $this->Manager,
-            ['fields' => $emptyValue]
+            ['fields' => $emptyValue],
         );
     }
 
@@ -78,7 +78,7 @@ class BaseTest extends TestCase
         $filter = new TestFilter(
             'name',
             $this->Manager,
-            ['fields' => $nonEmptyValue, 'aliasField' => false]
+            ['fields' => $nonEmptyValue, 'aliasField' => false],
         );
         $this->assertEquals((array)$nonEmptyValue, $filter->fields());
     }
@@ -103,7 +103,7 @@ class BaseTest extends TestCase
         $filter = new TestFilter(
             $nonEmptyValue,
             $this->Manager,
-            ['fields' => 'fields']
+            ['fields' => 'fields'],
         );
         $this->assertSame($filter->name(), $nonEmptyValue);
     }
@@ -116,7 +116,7 @@ class BaseTest extends TestCase
         $filter = new TestFilter(
             'fields',
             $this->Manager,
-            ['alwaysRun' => true, 'filterEmpty' => true]
+            ['alwaysRun' => true, 'filterEmpty' => true],
         );
 
         $filter->setArgs(['fields' => '1']);
@@ -140,7 +140,7 @@ class BaseTest extends TestCase
         $filter = new TestFilter(
             'fields',
             $this->Manager,
-            ['defaultValue' => 'default']
+            ['defaultValue' => 'default'],
         );
 
         $filter->setArgs(['fields' => 'value']);
@@ -161,7 +161,7 @@ class BaseTest extends TestCase
         $filter = new TestFilter(
             'fields',
             $this->Manager,
-            ['defaultValue' => 'default']
+            ['defaultValue' => 'default'],
         );
 
         $filter->setConfig('multiValue', true);
@@ -177,7 +177,7 @@ class BaseTest extends TestCase
         $filter = new TestFilter(
             'fields',
             $this->Manager,
-            ['defaultValue' => 'default']
+            ['defaultValue' => 'default'],
         );
 
         $filter->setConfig('multiValueSeparator', '|');
@@ -194,7 +194,7 @@ class BaseTest extends TestCase
         $filter = new TestFilter(
             'fields',
             $this->Manager,
-            ['defaultValue' => 'default']
+            ['defaultValue' => 'default'],
         );
 
         $filter->setConfig('multiValue', true);
@@ -211,7 +211,7 @@ class BaseTest extends TestCase
         $filter = new TestFilter(
             'fields',
             $this->Manager,
-            ['defaultValue' => 'default']
+            ['defaultValue' => 'default'],
         );
 
         $filter->setConfig('multiValueSeparator', ' ');
@@ -235,7 +235,7 @@ class BaseTest extends TestCase
         $filter = new TestFilter(
             'field',
             $this->Manager,
-            []
+            [],
         );
 
         $this->assertEquals(['Articles.field'], $filter->fields());
@@ -246,7 +246,7 @@ class BaseTest extends TestCase
         $filter = new TestFilter(
             'name',
             $this->Manager,
-            ['fields' => ['field1', 'field2']]
+            ['fields' => ['field1', 'field2']],
         );
 
         $expected = ['Articles.field1', 'Articles.field2'];
@@ -264,7 +264,7 @@ class BaseTest extends TestCase
         $filter = new TestFilter(
             'fields',
             new Manager($repo),
-            ['aliasField' => true]
+            ['aliasField' => true],
         );
 
         $this->assertEquals(['fields'], $filter->fields());
@@ -280,7 +280,7 @@ class BaseTest extends TestCase
             $this->Manager,
             ['beforeProcess' => function ($query, $params) {
                 $query->where($params);
-            }]
+            }],
         );
 
         $filter->execute($this->Manager->getRepository()->find(), ['fields' => 'bar']);
@@ -328,7 +328,7 @@ class BaseTest extends TestCase
                 $params['extra'] = 'value';
 
                 return $params;
-            }]
+            }],
         );
 
         $filter->execute($this->Manager->getRepository()->find(), ['fields' => 'bar']);

--- a/tests/TestCase/Model/Filter/BaseTest.php
+++ b/tests/TestCase/Model/Filter/BaseTest.php
@@ -206,6 +206,30 @@ class BaseTest extends TestCase
     /**
      * @return void
      */
+    public function testValueMultiValueSeparatorExactMatching()
+    {
+        $filter = new TestFilter(
+            'fields',
+            $this->Manager,
+            ['defaultValue' => 'default']
+        );
+
+        $filter->setConfig('multiValueSeparator', ' ');
+        $filter->setConfig('multiValueExactMatching', true);
+
+        $filter->setArgs(['fields' => 'value1 "value2 and 3" value4']);
+        $this->assertEquals(['value1', 'value2 and 3', 'value4'], $filter->value());
+
+        $filter->setConfig('multiValueSeparator', ' ');
+        $filter->setConfig('multiValueExactMatching', '*');
+
+        $filter->setArgs(['fields' => 'value1 *value2 and 3* value4']);
+        $this->assertEquals(['value1', 'value2 and 3', 'value4'], $filter->value());
+    }
+
+    /**
+     * @return void
+     */
     public function testFieldAliasing()
     {
         $filter = new TestFilter(

--- a/tests/TestCase/Model/Filter/BooleanTest.php
+++ b/tests/TestCase/Model/Filter/BooleanTest.php
@@ -29,11 +29,11 @@ class BooleanTest extends TestCase
         $this->assertTrue($result);
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.is_active = \:c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [true],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -51,11 +51,11 @@ class BooleanTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.is_active = \:c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [false],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -73,11 +73,11 @@ class BooleanTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.is_active = \:c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [true],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -95,11 +95,11 @@ class BooleanTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.is_active = \:c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [false],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -117,11 +117,11 @@ class BooleanTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.is_active = \:c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [true],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -139,11 +139,11 @@ class BooleanTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.is_active = \:c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [false],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -161,11 +161,11 @@ class BooleanTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.is_active = \:c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [true],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -183,11 +183,11 @@ class BooleanTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.is_active = \:c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [false],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -205,11 +205,11 @@ class BooleanTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.is_active = \:c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [true],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -224,11 +224,11 @@ class BooleanTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.is_active = \:c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [false],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -283,11 +283,11 @@ class BooleanTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE \(Articles\.is_active = :c0 OR Articles\.other = :c1\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [true, true],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -308,11 +308,11 @@ class BooleanTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE \(Articles\.is_active = :c0 AND Articles\.other = :c1\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [true, true],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -330,11 +330,11 @@ class BooleanTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.is_active = :c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [true],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 

--- a/tests/TestCase/Model/Filter/CallbackTest.php
+++ b/tests/TestCase/Model/Filter/CallbackTest.php
@@ -34,11 +34,11 @@ class CallbackTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE title = \:c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             ['test'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 

--- a/tests/TestCase/Model/Filter/CompareTest.php
+++ b/tests/TestCase/Model/Filter/CompareTest.php
@@ -28,11 +28,11 @@ class CompareTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.created >= :c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['2012-01-01 00:00:00'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -50,11 +50,11 @@ class CompareTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE \(Articles\.created >= :c0 AND Articles\.modified >= :c1\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['2012-01-01 00:00:00', '2012-01-01 00:00:00'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -72,11 +72,11 @@ class CompareTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE \(Articles\.created >= :c0 OR Articles\.modified >= :c1\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['2012-01-01 00:00:00', '2012-01-01 00:00:00'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -111,12 +111,12 @@ class CompareTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.created >= :c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
 
         $this->assertEquals(
             ['2012-01-01 00:00:00'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 

--- a/tests/TestCase/Model/Filter/ExistsTest.php
+++ b/tests/TestCase/Model/Filter/ExistsTest.php
@@ -30,7 +30,7 @@ class ExistsTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE \(Articles\.number\) IS NOT NULL$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
     }
 
@@ -50,7 +50,7 @@ class ExistsTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE \(Articles\.number\) IS NULL$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
     }
 
@@ -72,11 +72,11 @@ class ExistsTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.number != \:c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [''],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -98,11 +98,11 @@ class ExistsTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.number = \:c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [''],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -158,7 +158,7 @@ class ExistsTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE \(\(Articles\.number\) IS NOT NULL OR \(Articles\.title\) IS NOT NULL\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
     }
 }

--- a/tests/TestCase/Model/Filter/FinderTest.php
+++ b/tests/TestCase/Model/Filter/FinderTest.php
@@ -31,11 +31,11 @@ class FinderTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE \(Articles\.is_active = \:c0 AND foo = \:c1\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [true, 'bar'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -58,11 +58,11 @@ class FinderTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE title = :c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             ['foo'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -85,11 +85,11 @@ class FinderTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE user_id = :c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [1],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -122,11 +122,11 @@ class FinderTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE user_id = :c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [1],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -155,7 +155,7 @@ class FinderTest extends TestCase
 
         $this->assertSame(
             [],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -190,11 +190,11 @@ class FinderTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE \(title\) IS NULL$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -228,11 +228,11 @@ class FinderTest extends TestCase
         $filter->process();
         $this->assertMatchesRegularExpression(
             '/WHERE \(user_id\) IS NULL$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             [],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 

--- a/tests/TestCase/Model/Filter/LikeTest.php
+++ b/tests/TestCase/Model/Filter/LikeTest.php
@@ -29,11 +29,11 @@ class LikeTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.title LIKE \:c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             ['test'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
 
         $filter->setConfig('comparison', 'ILIKE');
@@ -42,11 +42,11 @@ class LikeTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.title ILIKE \:c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             ['test'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -64,11 +64,11 @@ class LikeTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.title LIKE :c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             ['foo'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -89,11 +89,11 @@ class LikeTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE \(Articles\.title LIKE :c0 OR Articles\.other LIKE :c1\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['foo', 'foo'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -111,11 +111,11 @@ class LikeTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE \(Articles\.title LIKE :c0 OR Articles\.title LIKE :c1\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['foo', 'bar'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -136,11 +136,11 @@ class LikeTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE \(Articles\.title LIKE :c0 AND Articles\.title LIKE :c1\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['foo', 'bar'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -162,11 +162,11 @@ class LikeTest extends TestCase
         $this->assertMatchesRegularExpression(
             '/WHERE \(\(Articles\.title LIKE :c0 OR Articles\.title LIKE :c1\) ' .
                 'OR \(Articles\.other LIKE :c2 OR Articles\.other LIKE :c3\)\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['foo', 'bar', 'foo', 'bar'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -189,11 +189,11 @@ class LikeTest extends TestCase
         $this->assertMatchesRegularExpression(
             '/WHERE \(\(Articles\.title LIKE :c0 OR Articles\.title LIKE :c1\) ' .
                 'AND \(Articles\.other LIKE :c2 OR Articles\.other LIKE :c3\)\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['foo', 'bar', 'foo', 'bar'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -274,11 +274,11 @@ class LikeTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.title LIKE :c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['default'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -315,7 +315,7 @@ class LikeTest extends TestCase
         $filter->getQuery()->sql();
         $this->assertEquals(
             ['part\_1 _ 100\% %'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -335,7 +335,7 @@ class LikeTest extends TestCase
         $filter->getQuery()->sql();
         $this->assertEquals(
             ['part[_]1 _ 100[%] %'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -355,7 +355,7 @@ class LikeTest extends TestCase
         $filter->getQuery()->sql();
         $this->assertEquals(
             ['%22[%] 44[_]%'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -375,7 +375,7 @@ class LikeTest extends TestCase
         $filter->getQuery()->sql();
         $this->assertEquals(
             ['%22\% 44\_%'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -390,7 +390,7 @@ class LikeTest extends TestCase
         $filter = new Like(
             'title',
             $manager,
-            ['before' => true, 'after' => true, 'wildcardAny' => '%', 'wildcardOne' => '_']
+            ['before' => true, 'after' => true, 'wildcardAny' => '%', 'wildcardOne' => '_'],
         );
         $filter->setArgs(['title' => '22% 44_']);
         $filter->setQuery($articles->find());
@@ -399,7 +399,7 @@ class LikeTest extends TestCase
         $filter->getQuery()->sql();
         $this->assertEquals(
             ['%22% 44_%'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -414,7 +414,7 @@ class LikeTest extends TestCase
         $filter = new Like(
             'title',
             $manager,
-            ['before' => true, 'after' => true, 'wildcardAny' => '%', 'wildcardOne' => '_', 'escaper' => 'Search.Sqlserver']
+            ['before' => true, 'after' => true, 'wildcardAny' => '%', 'wildcardOne' => '_', 'escaper' => 'Search.Sqlserver'],
         );
         $filter->setArgs(['title' => '22% 44_']);
         $filter->setQuery($articles->find());
@@ -423,7 +423,7 @@ class LikeTest extends TestCase
         $filter->getQuery()->sql();
         $this->assertEquals(
             ['%22% 44_%'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 }

--- a/tests/TestCase/Model/Filter/ValueTest.php
+++ b/tests/TestCase/Model/Filter/ValueTest.php
@@ -28,11 +28,11 @@ class ValueTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.title = :c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['test'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -50,11 +50,11 @@ class ValueTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.title = :c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['foo'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -74,11 +74,11 @@ class ValueTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE \(Articles\.title = :c0 OR Articles\.other = :c1\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['foo', 'foo'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -99,11 +99,11 @@ class ValueTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE \(Articles\.title = :c0 AND Articles\.other = :c1\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['foo', 'foo'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -121,11 +121,11 @@ class ValueTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.title IN \(:c0,:c1\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['foo', 'bar'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -146,11 +146,11 @@ class ValueTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.title IN \(:c0,:c1\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['foo', 'bar'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -172,11 +172,11 @@ class ValueTest extends TestCase
         $this->assertMatchesRegularExpression(
             '/WHERE \(Articles\.title IN \(:c0,:c1\) ' .
             'OR Articles\.other IN \(:c2,:c3\)\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['foo', 'bar', 'foo', 'bar'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -199,11 +199,11 @@ class ValueTest extends TestCase
         $this->assertMatchesRegularExpression(
             '/WHERE \(Articles\.title IN \(:c0,:c1\) ' .
             'AND Articles\.other IN \(:c2,:c3\)\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['foo', 'bar', 'foo', 'bar'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -221,11 +221,11 @@ class ValueTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.title IN \(:c0\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             [['bar']],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -259,11 +259,11 @@ class ValueTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.title = :c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['default'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -300,11 +300,11 @@ class ValueTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.title IN \(:c0,:c1\)$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertEquals(
             ['foo', 'bar'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 
@@ -324,11 +324,11 @@ class ValueTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/WHERE Articles\.number != :c0$/',
-            $filter->getQuery()->sql()
+            $filter->getQuery()->sql(),
         );
         $this->assertSame(
             ['3'],
-            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value')
+            Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
     }
 }

--- a/tests/TestCase/View/Helper/SearchHelperTest.php
+++ b/tests/TestCase/View/Helper/SearchHelperTest.php
@@ -38,7 +38,7 @@ class SearchHelperTest extends TestCase
         Router::createRouteBuilder('/')->scope('/', function (RouteBuilder $routes) {
             $routes->connect(
                 '/controller/action',
-                ['controller' => 'Controller', 'action' => 'action']
+                ['controller' => 'Controller', 'action' => 'action'],
             );
             $routes->fallbacks();
         });


### PR DESCRIPTION
This enables exact quote matches
```php
        $filter->setConfig('multiValueSeparator', ' ');
        $filter->setConfig('multiValueExactMatching', true);

        $filter->setArgs(['fields' => 'value1 "value2 and 3" value4']);
        $this->assertEquals(['value1', 'value2 and 3', 'value4'], $filter->value());

        $filter->setConfig('multiValueSeparator', ' ');
        $filter->setConfig('multiValueExactMatching', '*');

        $filter->setArgs(['fields' => 'value1 *value2 and 3* value4']);
        $this->assertEquals(['value1', 'value2 and 3', 'value4'], $filter->value());
```

Changes are in the 1st commit.
The 2nd is just to make CS happy again.