### PR TITLE
Minor refactoring of multi value parsing

### DIFF
--- a/docs/filters-and-examples.md
+++ b/docs/filters-and-examples.md
@@ -162,7 +162,7 @@ The following options are supported by all filters except `Callback` and `Finder
   auto-tokenize multiple values using a specific separator string. If disabled, the data
   must be an in form of an array.
 
-- `multiValueExactMatching` (`bool|string`, defaults to `false`) If enabled, this will match
+- `multiValueExactMatching` (`true|string`, defaults to `null`) If enabled, this will match
   phrases using a matching character (defaults to `"`). You can also define one yourself.
   Note: This only works for `multiValueSeparator` set to a single space as character.
 

--- a/src/Model/Filter/Base.php
+++ b/src/Model/Filter/Base.php
@@ -69,7 +69,7 @@ abstract class Base
             'defaultValue' => null,
             'multiValue' => false,
             'multiValueSeparator' => null,
-            'multiValueExactMatching' => false,
+            'multiValueExactMatching' => null,
             'flatten' => true,
             'beforeProcess' => null,
         ];
@@ -209,22 +209,25 @@ abstract class Base
         }
 
         if ($this->getConfig('multiValueSeparator')) {
-            if (!$this->getConfig('multiValueExactMatching')) {
-                return explode($this->getConfig('multiValueSeparator'), $value);
-            }
-
-            return $this->parseSearchTerms($value);
+            return $this->parseValue($value);
         }
 
         return $value;
     }
 
     /**
-     * @param string $input
+     * Split string into array of values.
+     *
+     * @param string $value
+     * @throws \UnexpectedValueException
      * @return array<string>
      */
-    protected function parseSearchTerms(string $input): array
+    protected function parseValue(string $value): array
     {
+        if (!$this->getConfig('multiValueExactMatching')) {
+            return explode($this->getConfig('multiValueSeparator'), $value);
+        }
+
         if ($this->getConfig('multiValueSeparator') !== ' ') {
             throw new UnexpectedValueException(
                 'The `multiValueSeparator` option must be a single space when `multiValueExactMatching` is used.',
@@ -242,7 +245,7 @@ abstract class Base
         // Match quoted phrases and unquoted words
         preg_match_all(
             '/' . $escapedQuoteChar . '([^' . $escapedQuoteChar . ']+)' . $escapedQuoteChar . '|\S+/',
-            $input,
+            $value,
             $matches,
         );
 


### PR DESCRIPTION
@dereuromark I just did minor refactoring to keep all string splitting code in the same method. While the string parsing might only be used in `Like` or `Value` there might be custom filters relying on it too, so keeping it in `Base` for now to avoid any BC break. Don't want to do a new major for it.