### PR TITLE
Fix up empty via callable for more dynamic use cases.

### DIFF
--- a/docs/additional-docs.md
+++ b/docs/additional-docs.md
@@ -12,6 +12,31 @@ You can use `queryStringBlacklist` option of `SearchComponent` to set an array o
 form fields that should not end up in the query when extracting params from POST
 request and redirecting.
 
+## Emptiness based on more than one field.
+If you need to determine `emptyValues` dynamically or based on multiple fields
+(e.g. price range min/max), you can use callables for it and pass this to the `SearchComponent` config:
+```php
+$callable = function ($value, array $params) use (Price $minPrice, Price $maxPrice): bool {
+    $minValue = (int)$minPrice->price;
+    $maxValue = (int)ceil((float)$maxPrice->price);
+
+    if (empty($params['price_min']) || empty($params['price_max'])) {
+        return true;
+    }
+
+    if ((string)$minValue === $params['price_min'] && (string)$maxValue === $params['price_max']) {
+        return true;
+    }
+
+    return false;
+};
+$this->Search->setConfig('emptyValues', [
+    'price_min' => $callable,
+    'price_max' => $callable,
+]);
+```
+It will evaluate the two fields together.
+
 ## Filtering and FormProtection component
 When the FormProtection component is activated for the whole controller, it should be disabled for the paginated actions:
 ```php

--- a/docs/additional-docs.md
+++ b/docs/additional-docs.md
@@ -14,9 +14,9 @@ request and redirecting.
 
 ## Emptiness based on more than one field.
 If you need to determine `emptyValues` dynamically or based on multiple fields
-(e.g. price range min/max), you can use callables for it and pass this to the `SearchComponent` config:
+(e.g. price range min/max), you can use closures for it and pass this to the `SearchComponent` config:
 ```php
-$callable = function ($value, array $params) use (Price $minPrice, Price $maxPrice): bool {
+$checkEmpty = function ($value, array $params) use (Price $minPrice, Price $maxPrice): bool {
     $minValue = (int)$minPrice->price;
     $maxValue = (int)ceil((float)$maxPrice->price);
 
@@ -31,8 +31,8 @@ $callable = function ($value, array $params) use (Price $minPrice, Price $maxPri
     return false;
 };
 $this->Search->setConfig('emptyValues', [
-    'price_min' => $callable,
-    'price_max' => $callable,
+    'price_min' => $checkEmpty,
+    'price_max' => $checkEmpty,
 ]);
 ```
 It will evaluate the two fields together.

--- a/docs/filters-and-examples.md
+++ b/docs/filters-and-examples.md
@@ -298,7 +298,7 @@ getting the query string attached for this "disabled" search field, you can set
             'my_checkbox' => '0',
             'my_custom_field' => callable($value, array $params): bool {
                 //return true to make it behave empty;
-            }
+            },
         ],
     ]);
 ```
@@ -307,7 +307,7 @@ This is needed for the "isSearch" work as expected.
 
 ## Custom filter
 
-You can create your own filter by by creating a filter class under `src/Model/Filter`.
+You can create your own filter by creating a filter class under `src/Model/Filter`.
 
 ```php
 <?php

--- a/docs/filters-and-examples.md
+++ b/docs/filters-and-examples.md
@@ -296,7 +296,7 @@ getting the query string attached for this "disabled" search field, you can set
         ...
         'emptyValues' => [
             'my_checkbox' => '0',
-            'my_custom_field' => callable($value, array $params): bool {
+            'my_custom_field' => function ($value, array $params): bool {
                 //return true to make it behave empty;
             },
         ],

--- a/docs/filters-and-examples.md
+++ b/docs/filters-and-examples.md
@@ -296,6 +296,9 @@ getting the query string attached for this "disabled" search field, you can set
         ...
         'emptyValues' => [
             'my_checkbox' => '0',
+            'my_custom_field' => callable($value, array $params): bool {
+                //return true to make it behave empty;
+            }
         ],
     ]);
 ```

--- a/src/Controller/Component/SearchComponent.php
+++ b/src/Controller/Component/SearchComponent.php
@@ -28,7 +28,7 @@ class SearchComponent extends Component
      *   Defaults to the Paginator `'sort'`, `'direction'` and `'limit'` ones.
      * - `queryStringBlacklist` : An array of form fields that should not end up in the query.
      * - `emptyValues` : A map of fields and their values to be considered empty
-     *   (will not be passed along in the URL).
+     *   (will not be passed along in the URL). Use callables for more control (return true for "empty").
      * - `modelClass` : Configure the controller's modelClass to be used for the query, used to
      *   populate the _isSearch view variable to allow for a reset button, for example.
      *   Set to false to disable the auto-setting of the view variable.
@@ -144,6 +144,15 @@ class SearchComponent extends Component
 
         foreach ((array)$this->getConfig('emptyValues') as $field => $value) {
             if (!isset($params[$field])) {
+                continue;
+            }
+
+            if (is_callable($value)) {
+                $isEmpty = $value($params[$field], $params);
+                if ($isEmpty) {
+                    unset($params[$field]);
+                }
+
                 continue;
             }
 

--- a/src/Controller/Component/SearchComponent.php
+++ b/src/Controller/Component/SearchComponent.php
@@ -6,6 +6,7 @@ namespace Search\Controller\Component;
 use Cake\Controller\Component;
 use Cake\Http\Response;
 use Cake\Utility\Hash;
+use Closure;
 use UnexpectedValueException;
 
 /**
@@ -28,7 +29,7 @@ class SearchComponent extends Component
      *   Defaults to the Paginator `'sort'`, `'direction'` and `'limit'` ones.
      * - `queryStringBlacklist` : An array of form fields that should not end up in the query.
      * - `emptyValues` : A map of fields and their values to be considered empty
-     *   (will not be passed along in the URL). Use callables for more control (return true for "empty").
+     *   (will not be passed along in the URL). Use closure for more control (return true for "empty").
      * - `modelClass` : Configure the controller's modelClass to be used for the query, used to
      *   populate the _isSearch view variable to allow for a reset button, for example.
      *   Set to false to disable the auto-setting of the view variable.
@@ -147,7 +148,7 @@ class SearchComponent extends Component
                 continue;
             }
 
-            if (is_callable($value)) {
+            if ($value instanceof Closure) {
                 $isEmpty = $value($params[$field], $params);
                 if ($isEmpty) {
                     unset($params[$field]);

--- a/tests/TestCase/Controller/Component/SearchComponentTest.php
+++ b/tests/TestCase/Controller/Component/SearchComponentTest.php
@@ -134,6 +134,33 @@ class SearchComponentTest extends TestCase
     /**
      * @return void
      */
+    public function testInitializePostWithEmptyValuesCallable()
+    {
+        $request = $this->Controller->getRequest()
+            ->withAttribute('params', [
+                'controller' => 'Posts',
+                'action' => 'index',
+                'pass' => ['pass'],
+            ])
+            ->withRequestTarget('/Posts/index/pass')
+            ->withData('foo', 'bar')
+            ->withData('checkbox', '0')
+            ->withEnv('REQUEST_METHOD', 'POST');
+
+        $this->Controller->setRequest($request);
+
+        $this->Search->configShallow('emptyValues', [
+            'checkbox' => function($value, array $params): bool {
+                return $value === '0';
+            },
+        ]);
+        $response = $this->Search->startup();
+        $this->assertEquals('http://localhost/Posts/index/pass?foo=bar', $response->getHeaderLine('Location'));
+    }
+
+    /**
+     * @return void
+     */
     public function testInitializePostWithQueryStringWhitelist()
     {
         $request = $this->Controller->getRequest()

--- a/tests/TestCase/Controller/Component/SearchComponentTest.php
+++ b/tests/TestCase/Controller/Component/SearchComponentTest.php
@@ -150,7 +150,7 @@ class SearchComponentTest extends TestCase
         $this->Controller->setRequest($request);
 
         $this->Search->configShallow('emptyValues', [
-            'checkbox' => function($value, array $params): bool {
+            'checkbox' => function ($value, array $params): bool {
                 return $value === '0';
             },
         ]);


### PR DESCRIPTION
Resolves https://github.com/FriendsOfCake/search/issues/347
```php
	$callable = function ($value, array $params) use ($minPrice, $maxPrice): bool {
		$minValue = $minPrice ? (int)$minPrice->price : 0;
		$maxValue = $maxPrice ? (int)ceil((float)$maxPrice->price) : 0;

		if (!$minPrice && !$maxPrice) {
			return true;
		}
		if (empty($params['price_min']) || empty($params['price_max'])) {
			return true;
		}

		if ((string)$minValue === $params['price_min'] && (string)$maxValue === $params['price_max']) {
			return true;
		}

		return false;
	};
	$this->Search->setConfig('emptyValues', [
		'price_min' => $callable,
		'price_max' => $callable,
	]);
```	

With this I dont need hacks anymore in the controller actions (that still dont properly work fully)