### PR TITLE
Hotfix Merge issue.

### DIFF
--- a/src/Controller/Component/SearchComponent.php
+++ b/src/Controller/Component/SearchComponent.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Search\Controller\Component;
 
 use Cake\Controller\Component;
+use Cake\Controller\ComponentRegistry;
+use Cake\Core\Configure;
 use Cake\Event\EventInterface;
 use Cake\Utility\Hash;
 use Closure;
@@ -50,6 +52,17 @@ class SearchComponent extends Component
             'Controller.beforeRender' => 'beforeRender',
         ],
     ];
+
+    /**
+     * @param \Cake\Controller\ComponentRegistry $registry
+     * @param array<string, mixed> $config
+     */
+    public function __construct(ComponentRegistry $registry, array $config = [])
+    {
+        $this->_defaultConfig = (array)Configure::read('Search') + $this->_defaultConfig;
+
+        parent::__construct($registry, $config);
+    }
 
     /**
      * Get the Controller callbacks this Component is interested in.


### PR DESCRIPTION
Hotfixing https://github.com/FriendsOfCake/search/issues/352 for now.

Allows to set the defaults to empty from the outside for now, and also more globally - via opt in Search config key.