### PR TITLE
Use Form::execute() instead of Form::validate().

### DIFF
--- a/src/Controller/Component/SearchComponent.php
+++ b/src/Controller/Component/SearchComponent.php
@@ -104,7 +104,7 @@ class SearchComponent extends Component
 
         $params = (array)$this->getController()->getRequest()->getData();
 
-        if ($form !== null && !$form->validate($params)) {
+        if ($form !== null && !$form->execute($params)) {
             $this->getController()->set('searchForm', $form);
 
             return;


### PR DESCRIPTION
This allows for use cases like saving the searches made by the user.