### PR TITLE
Fix extraParams leak, Callback null contract, Like driver detection

### DIFF
--- a/docs/filters-and-examples.md
+++ b/docs/filters-and-examples.md
@@ -288,12 +288,44 @@ The following options are supported by all filters except `Callback` and `Finder
   (`_`) is being escaped in case used the search term.
 
 - `escaper` (`string`, default to `null`) Defines the escaper that should
-  escape `%` and `_`. If no escaper is set (`escapeDriver => 'null'`) the escaper
-  is set by database driver. If the driver is `Sqlserver` the `SqlserverEscaper`
-  is used (escaping `%` to `[%]` and `_` to `[_]`). In all other cases the
-  `DefaultEscaper` is used (escaping `%` to `\%` and `_` to `\_`). You can add an
-  own escaper by adding a escaper in `App\Model\Filter\Escaper\OwnEscaper` and
-  settings `'escaper' => 'App.Own'`.
+  escape `%` and `_`. If no escaper is set (the default) the escaper is
+  resolved from the active database driver via the `escapers` map (see
+  below). You can pin a specific escaper for a filter by setting this option
+  (e.g. `'escaper' => 'App.Own'`) — the active driver is then ignored.
+
+- `escapers` (`array<string, string>`, defaults to a built-in map) Maps a
+  Cake `Driver` class name to an escaper class spec (Cake plugin-syntax,
+  e.g. `Search.Sqlserver`). Used when `escaper` is left at `null`. The
+  shipped defaults are:
+
+  - `Cake\Database\Driver\Sqlserver::class => 'Search.Sqlserver'`
+  - `Cake\Database\Driver\Postgres::class => 'Search.Postgres'`
+
+  Apps register custom escapers by extending this map at filter setup
+  without needing to subclass the filter:
+
+  ```php
+  use App\Database\Driver\MyMariaDb;
+
+  $searchManager->like('title', [
+      'escapers' => [
+          MyMariaDb::class => 'App.MyMariaDb',
+      ],
+  ]);
+  ```
+
+  Match is done via `instanceof`, so a subclassed driver still resolves
+  correctly. Entries are evaluated in iteration order; list more specific
+  driver classes before less specific ones. When no entry matches the active
+  driver, `Search.Default` is used (escaping `%` to `\%` and `_` to `\_`).
+
+  The default `SqlserverEscaper` escapes `%` to `[%]` and `_` to `[_]`. The
+  default `PostgresEscaper` currently inherits from `DefaultEscaper`; it
+  exists so Postgres-specific rules can diverge in future without breaking
+  the public API.
+
+  Register your own escaper by adding a class in
+  `App\Model\Filter\Escaper\OwnEscaper` implementing `EscaperInterface`.
 
 ### `Value`
 

--- a/src/Model/Filter/Callback.php
+++ b/src/Model/Filter/Callback.php
@@ -40,7 +40,7 @@ class Callback extends Base
                 '7.9.0',
                 sprintf(
                     'Callback filter `%s` returned null; callbacks must return bool to control isSearch(). '
-                    . 'In a future version returning null/void will throw.',
+                    . 'In a future version returning null/void will throw an error.',
                     $this->name(),
                 ),
             );

--- a/src/Model/Filter/Callback.php
+++ b/src/Model/Filter/Callback.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Search\Model\Filter;
 
+use function Cake\Core\deprecationWarning;
+
 class Callback extends Base
 {
     /**
@@ -17,15 +19,35 @@ class Callback extends Base
     /**
      * Modify query using callback.
      *
+     * The callback must return a `bool` indicating whether it modified the
+     * query (controls `isSearch()`). Returning `null`/void is supported for
+     * backwards compatibility but is deprecated and will throw in a future
+     * version.
+     *
      * @return bool
      */
     public function process(): bool
     {
-        return call_user_func(
+        $result = call_user_func(
             $this->getConfig('callback'),
             $this->getQuery(),
             $this->getArgs(),
             $this,
-        ) ?? true;
+        );
+
+        if ($result === null) {
+            deprecationWarning(
+                '7.9.0',
+                sprintf(
+                    'Callback filter `%s` returned null; callbacks must return bool to control isSearch(). '
+                    . 'In a future version returning null/void will throw.',
+                    $this->name(),
+                ),
+            );
+
+            return true;
+        }
+
+        return $result;
     }
 }

--- a/src/Model/Filter/Escaper/PostgresEscaper.php
+++ b/src/Model/Filter/Escaper/PostgresEscaper.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Search\Model\Filter\Escaper;
+
+/**
+ * Escaper for the PostgreSQL driver.
+ *
+ * Inherits wildcard handling from the default escaper but exists as a
+ * distinct class so the `Like` filter can select it via `instanceof` against
+ * the driver and so it can be overridden independently.
+ *
+ * Postgres uses `LIKE` for case-sensitive matching and `ILIKE` for the
+ * case-insensitive form; users who want the case-insensitive behavior set
+ * `comparison => 'ILIKE'` on the filter or on the connection-aware default.
+ */
+class PostgresEscaper extends DefaultEscaper
+{
+}

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Search\Model\Filter;
 
 use Cake\Core\App;
+use Cake\Database\Driver\Postgres;
+use Cake\Database\Driver\Sqlserver;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
 use InvalidArgumentException;
@@ -163,14 +165,15 @@ class Like extends Base
                 );
             }
 
-            $driver = get_class($query->getConnection()->getDriver());
-            $driverName = 'Sqlserver';
-            if (substr_compare($driver, $driverName, -strlen($driverName)) === 0) {
-                $class = 'Search.Sqlserver';
-            } else {
-                $class = 'Search.Default';
-            }
-            $this->setConfig('escaper', $class);
+            $driver = $query->getConnection()->getDriver();
+            $class = match (true) {
+                $driver instanceof Sqlserver => 'Search.Sqlserver',
+                $driver instanceof Postgres => 'Search.Postgres',
+                default => 'Search.Default',
+            };
+            // Intentionally NOT caching the resolved class on the filter:
+            // re-using the same filter instance against a query backed by a
+            // different connection / driver must resolve afresh.
         }
 
         /** @var class-string<\Search\Model\Filter\Escaper\EscaperInterface>|null $className */

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Search\Model\Filter;
 
 use Cake\Core\App;
+use Cake\Database\Driver;
 use Cake\Database\Driver\Postgres;
 use Cake\Database\Driver\Sqlserver;
 use Cake\ORM\Query\SelectQuery;
@@ -24,6 +25,23 @@ class Like extends Base
     /**
      * Default configuration.
      *
+     * `escapers` maps a Cake database driver class name to an escaper class
+     * spec (Cake plugin-syntax, e.g. `Search.Sqlserver`). It is consulted by
+     * `_setEscaper()` via `instanceof` so a subclassed driver still matches.
+     * Apps register custom escapers by extending this map at filter setup:
+     *
+     * ```php
+     * $searchManager->like('title', [
+     *     'escapers' => [
+     *         App\Database\Driver\MyMariaDb::class => 'App.MyMariaDb',
+     *     ],
+     * ]);
+     * ```
+     *
+     * Entries are evaluated in iteration order; place more specific driver
+     * classes before less specific ones. When no entry matches the active
+     * driver, `Search.Default` is used.
+     *
      * @var array<string, mixed>
      */
     protected array $_defaultConfig = [
@@ -35,6 +53,10 @@ class Like extends Base
         'wildcardAny' => '*',
         'wildcardOne' => '?',
         'escaper' => null,
+        'escapers' => [
+            Sqlserver::class => 'Search.Sqlserver',
+            Postgres::class => 'Search.Postgres',
+        ],
         'colType' => [],
     ];
 
@@ -166,11 +188,7 @@ class Like extends Base
             }
 
             $driver = $query->getConnection()->getDriver();
-            $class = match (true) {
-                $driver instanceof Sqlserver => 'Search.Sqlserver',
-                $driver instanceof Postgres => 'Search.Postgres',
-                default => 'Search.Default',
-            };
+            $class = $this->_resolveEscaperClass($driver);
             // Intentionally NOT caching the resolved class on the filter:
             // re-using the same filter instance against a query backed by a
             // different connection / driver must resolve afresh.
@@ -186,5 +204,31 @@ class Like extends Base
         }
 
         $this->_escaper = new $className($this->getConfig());
+    }
+
+    /**
+     * Resolve the escaper class spec for the given driver instance against
+     * the configured `escapers` map. Falls back to `Search.Default` when no
+     * map entry matches.
+     *
+     * Override this method (or supply a custom `escapers` map) to register
+     * driver-specific escapers without subclassing the filter.
+     *
+     * @param \Cake\Database\Driver $driver Driver instance to resolve against.
+     * @return string Cake plugin-syntax escaper class spec.
+     */
+    protected function _resolveEscaperClass(Driver $driver): string
+    {
+        $escapers = (array)$this->getConfig('escapers');
+        foreach ($escapers as $driverClass => $escaperClass) {
+            if (!is_string($driverClass) || $driverClass === '') {
+                continue;
+            }
+            if ($driver instanceof $driverClass) {
+                return (string)$escaperClass;
+            }
+        }
+
+        return 'Search.Default';
     }
 }

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -46,11 +46,11 @@ class Processor
 
         foreach ($filters as $filter) {
             $extraParams = $filter->getConfig('extraParams', []);
-            if ($extraParams) {
-                $filterParams += array_intersect_key($params, array_flip($extraParams));
-            }
+            $currentParams = $extraParams
+                ? $filterParams + array_intersect_key($params, array_flip($extraParams))
+                : $filterParams;
 
-            $result = $filter->execute($query, $filterParams);
+            $result = $filter->execute($query, $currentParams);
             if ($result !== false) {
                 $filtered = true;
             }

--- a/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SearchBehaviorTest.php
@@ -326,6 +326,8 @@ class SearchBehaviorTest extends TestCase
         $manager->callback('field1', [
             'callback' => function (SelectQuery $query, array $args) use (&$result) {
                 $result = $args;
+
+                return true;
             },
             'extraParams' => ['extra_field'],
         ]);
@@ -336,6 +338,43 @@ class SearchBehaviorTest extends TestCase
             'field1' => 'foo',
             'extra_field' => 'bar',
         ], $result);
+    }
+
+    /**
+     * A filter that declares `extraParams` must not leak those params into
+     * subsequent filters that did not request them.
+     */
+    public function testExtraParamsDoNotLeakBetweenFilters(): void
+    {
+        $seenByA = [];
+        $seenByB = [];
+
+        $manager = $this->Articles->getBehavior('Search')->searchManager();
+        $manager->callback('with_extra', [
+            'callback' => function (SelectQuery $query, array $args) use (&$seenByA): bool {
+                $seenByA = $args;
+
+                return true;
+            },
+            'extraParams' => ['extra_field'],
+        ]);
+        $manager->callback('without_extra', [
+            'callback' => function (SelectQuery $query, array $args) use (&$seenByB): bool {
+                $seenByB = $args;
+
+                return true;
+            },
+        ]);
+
+        $this->Articles->find('search', search: [
+            'with_extra' => '1',
+            'without_extra' => '1',
+            'extra_field' => 'leak?',
+        ]);
+
+        $this->assertArrayHasKey('extra_field', $seenByA);
+        $this->assertSame('leak?', $seenByA['extra_field']);
+        $this->assertArrayNotHasKey('extra_field', $seenByB);
     }
 
     /**

--- a/tests/TestCase/Model/Filter/CallbackTest.php
+++ b/tests/TestCase/Model/Filter/CallbackTest.php
@@ -62,6 +62,12 @@ class CallbackTest extends TestCase
         $filter->setArgs(['title' => ['test']]);
         $filter->setQuery($articles->find());
 
+        // Cake's deprecationWarning() short-circuits when error_reporting()
+        // does not include E_USER_DEPRECATED; the lowest-deps CI matrix
+        // disables it. Force it on so the deprecation surfaces here.
+        $previousReporting = error_reporting();
+        error_reporting($previousReporting | E_USER_DEPRECATED);
+
         $deprecations = [];
         set_error_handler(function ($severity, $message) use (&$deprecations) {
             $deprecations[] = $message;
@@ -71,6 +77,7 @@ class CallbackTest extends TestCase
             $result = $filter->process();
         } finally {
             restore_error_handler();
+            error_reporting($previousReporting);
         }
 
         $this->assertTrue($result);

--- a/tests/TestCase/Model/Filter/CallbackTest.php
+++ b/tests/TestCase/Model/Filter/CallbackTest.php
@@ -62,9 +62,26 @@ class CallbackTest extends TestCase
         $filter->setArgs(['title' => ['test']]);
         $filter->setQuery($articles->find());
 
-        $this->deprecated(function () use ($filter) {
-            $this->assertTrue($filter->process());
-        });
+        $deprecations = [];
+        set_error_handler(function ($severity, $message) use (&$deprecations) {
+            $deprecations[] = $message;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $result = $filter->process();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertTrue($result);
+        $this->assertNotEmpty(
+            $deprecations,
+            'Expected a deprecation warning when the callback returns null.',
+        );
+        $this->assertStringContainsString(
+            'Callback filter `title` returned null',
+            implode("\n", $deprecations),
+        );
     }
 
     /**

--- a/tests/TestCase/Model/Filter/CallbackTest.php
+++ b/tests/TestCase/Model/Filter/CallbackTest.php
@@ -24,8 +24,10 @@ class CallbackTest extends TestCase
         $manager = new Manager($articles);
 
         $filter = new Callback('title', $manager, [
-            'callback' => function (SelectQuery $query, array $args, Callback $filter) {
+            'callback' => function (SelectQuery $query, array $args, Callback $filter): bool {
                 $query->where(['title' => 'test']);
+
+                return true;
             },
         ]);
         $filter->setArgs(['title' => ['test']]);
@@ -40,6 +42,29 @@ class CallbackTest extends TestCase
             ['test'],
             Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
+    }
+
+    /**
+     * A callback that forgets the `return` statement keeps the historic
+     * isSearch=true semantics but raises a deprecation pointing at it. In
+     * a future version this will throw instead.
+     */
+    public function testProcessNullReturnIsDeprecated()
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $manager = new Manager($articles);
+
+        $filter = new Callback('title', $manager, [
+            'callback' => function (SelectQuery $query, array $args, Callback $filter): void {
+                // intentionally no return
+            },
+        ]);
+        $filter->setArgs(['title' => ['test']]);
+        $filter->setQuery($articles->find());
+
+        $this->deprecated(function () use ($filter) {
+            $this->assertTrue($filter->process());
+        });
     }
 
     /**

--- a/tests/TestCase/Model/Filter/LikeTest.php
+++ b/tests/TestCase/Model/Filter/LikeTest.php
@@ -488,6 +488,66 @@ class LikeTest extends TestCase
      *
      * @return void
      */
+
+    /**
+     * Apps can register a custom escaper for a driver class via the
+     * `escapers` config map without subclassing the filter. The map is
+     * merged into the defaults at filter construction (Cake's normal
+     * `_defaultConfig` behavior), so existing mappings still apply.
+     *
+     * @return void
+     */
+    public function testCustomEscaperViaEscapersMap()
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $manager = new Manager($articles);
+
+        // The user has a driver subclass and wants to send it to a specific
+        // escaper. Map entries are evaluated in iteration order, so listing
+        // the subclass first overrides the shipped Sqlserver-class default.
+        $driver = new class extends Sqlserver {
+            public function connect(): void
+            {
+            }
+        };
+
+        $filter = new Like('title', $manager, [
+            'escapers' => [
+                $driver::class => 'Search.Default',
+            ],
+        ]);
+        $filter->setArgs(['title' => 'foo']);
+        $this->_invokeSetEscaper($filter, $this->_queryWithDriver($driver));
+
+        $this->assertInstanceOf(
+            DefaultEscaper::class,
+            $this->_resolvedEscaper($filter),
+        );
+    }
+
+    /**
+     * Unknown drivers (not in the escapers map and not in the shipped
+     * defaults) fall through to `Search.Default`.
+     *
+     * @return void
+     */
+    public function testEscaperFallsBackToDefaultWhenNoMatch()
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Like('title', $manager, [
+            // Explicitly empty map; no entry will match the sqlite driver.
+            'escapers' => [],
+        ]);
+        $filter->setArgs(['title' => 'foo']);
+        $this->_invokeSetEscaper($filter, $this->_queryWithDriver($articles->getConnection()->getDriver()));
+
+        $this->assertInstanceOf(
+            DefaultEscaper::class,
+            $this->_resolvedEscaper($filter),
+        );
+    }
+
     public function testEscaperResolvesAfreshPerQuery()
     {
         $articles = $this->getTableLocator()->get('Articles');

--- a/tests/TestCase/Model/Filter/LikeTest.php
+++ b/tests/TestCase/Model/Filter/LikeTest.php
@@ -3,9 +3,20 @@ declare(strict_types=1);
 
 namespace Search\Test\TestCase\Model\Filter;
 
+use Cake\Database\Connection;
+use Cake\Database\Driver;
+use Cake\Database\Driver\Postgres;
+use Cake\Database\Driver\Sqlserver;
+use Cake\ORM\Query\SelectQuery;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
+use ReflectionMethod;
+use ReflectionProperty;
 use Search\Manager;
+use Search\Model\Filter\Escaper\DefaultEscaper;
+use Search\Model\Filter\Escaper\EscaperInterface;
+use Search\Model\Filter\Escaper\PostgresEscaper;
+use Search\Model\Filter\Escaper\SqlserverEscaper;
 use Search\Model\Filter\Like;
 
 class LikeTest extends TestCase
@@ -425,5 +436,156 @@ class LikeTest extends TestCase
             ['%22% 44_%'],
             Hash::extract($filter->getQuery()->getValueBinder()->bindings(), '{s}.value'),
         );
+    }
+
+    /**
+     * Driver detection must use `instanceof` against the actual driver
+     * instance, not a substring match on its class name. A custom driver
+     * class that extends or wraps Sqlserver under a different name must
+     * still be detected as Sqlserver.
+     *
+     * @return void
+     */
+    public function testEscaperSelectionForSqlServerDriverSubclass()
+    {
+        $filter = $this->_filterWithDriver(new class extends Sqlserver {
+            public function connect(): void
+            {
+            }
+        });
+
+        $this->assertInstanceOf(
+            SqlserverEscaper::class,
+            $this->_resolvedEscaper($filter),
+        );
+    }
+
+    /**
+     * Postgres drivers must pick the new Postgres escaper rather than the
+     * default. This ensures that driver-specific wildcard rules can diverge
+     * in future without breaking the public API.
+     *
+     * @return void
+     */
+    public function testEscaperSelectionForPostgresDriver()
+    {
+        $filter = $this->_filterWithDriver(new class extends Postgres {
+            public function connect(): void
+            {
+            }
+        });
+
+        $this->assertInstanceOf(
+            PostgresEscaper::class,
+            $this->_resolvedEscaper($filter),
+        );
+    }
+
+    /**
+     * The resolved escaper must NOT stick on the filter instance: running
+     * `_setEscaper()` twice against queries backed by different drivers has
+     * to pick the correct escaper for each.
+     *
+     * @return void
+     */
+    public function testEscaperResolvesAfreshPerQuery()
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Like('title', $manager, []);
+        $filter->setArgs(['title' => 'foo']);
+
+        // First resolution: default (sqlite) -> Default escaper.
+        $this->_invokeSetEscaper($filter, $this->_queryWithDriver($articles->getConnection()->getDriver()));
+        $this->assertInstanceOf(
+            DefaultEscaper::class,
+            $this->_resolvedEscaper($filter),
+        );
+
+        // Second resolution on same filter: Sqlserver-backed query.
+        $this->_invokeSetEscaper($filter, $this->_queryWithDriver(
+            new class extends Sqlserver {
+                public function connect(): void
+                {
+                }
+            },
+        ));
+        $this->assertInstanceOf(
+            SqlserverEscaper::class,
+            $this->_resolvedEscaper($filter),
+        );
+    }
+
+    /**
+     * Build a Like filter, point it at a stub query with the given driver,
+     * and invoke `_setEscaper()` so we can inspect the resolved escaper.
+     *
+     * @param \Cake\Database\Driver $driver Driver instance the stub query exposes.
+     * @return \Search\Model\Filter\Like
+     */
+    protected function _filterWithDriver(Driver $driver): Like
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $manager = new Manager($articles);
+
+        $filter = new Like('title', $manager, []);
+        $filter->setArgs(['title' => 'foo']);
+        $this->_invokeSetEscaper($filter, $this->_queryWithDriver($driver));
+
+        return $filter;
+    }
+
+    /**
+     * Invoke the protected `_setEscaper()` with the given query attached,
+     * bypassing `process()` (and the schema introspection it would trigger).
+     */
+    protected function _invokeSetEscaper(Like $filter, SelectQuery $query): void
+    {
+        $filter->setQuery($query);
+        (new ReflectionMethod($filter, '_setEscaper'))->invoke($filter);
+    }
+
+    /**
+     * Build a `SelectQuery` stub whose `getConnection()->getDriver()` returns
+     * the supplied driver instance. The query is otherwise inert — only the
+     * driver-detection path of `_setEscaper()` reads from it.
+     */
+    protected function _queryWithDriver(Driver $driver): SelectQuery
+    {
+        $connection = new class ($driver) extends Connection {
+            public function __construct(private Driver $injectedDriver)
+            {
+                parent::__construct(['driver' => 'Cake\Database\Driver\Sqlite']);
+            }
+
+            public function getDriver(string $role = self::ROLE_WRITE): Driver
+            {
+                return $this->injectedDriver;
+            }
+        };
+
+        return new class ($connection) extends SelectQuery {
+            public function __construct(private Connection $stubConnection)
+            {
+            }
+
+            public function getConnection(): Connection
+            {
+                return $this->stubConnection;
+            }
+        };
+    }
+
+    /**
+     * Reach into the filter's protected `_escaper` property after process().
+     *
+     * @param \Search\Model\Filter\Like $filter Filter to inspect.
+     * @return \Search\Model\Filter\Escaper\EscaperInterface
+     */
+    protected function _resolvedEscaper(Like $filter): EscaperInterface
+    {
+        $reflection = new ReflectionProperty($filter, '_escaper');
+
+        return $reflection->getValue($filter);
     }
 }


### PR DESCRIPTION
## Summary

Three small independent fixes, one commit per fix so they can be reverted independently if needed.

### 1. `Processor::process()` — extraParams leak across filters

`$filterParams` was mutated in place inside the filter loop, so any filter that declared `extraParams => [...]` polluted that map for every filter that ran after it. A filter that did NOT request `extra_field` could still observe it via `getArgs()['extra_field']`, breaking the documented per-filter scoping. Build a per-iteration `$currentParams` view instead.

Regression test: `SearchBehaviorTest::testExtraParamsDoNotLeakBetweenFilters` — declares two callbacks, only the first requests `extra_field`, asserts the second's `args` is clean. Fails before the fix.

### 2. `Callback::process()` — null return contract

The docs (`docs/filters-and-examples.md:67`) and the per-plugin maintainer rule say callbacks must return `bool` to drive `isSearch()`. The implementation did `call_user_func(...) ?? true`, silently coercing a missing return into `isSearch=true`. The README/example at `docs/basic-configuration.md:46` itself omits the return statement, codifying the bug.

Soft-deprecation strategy: keep the historic `null → true` behavior for one minor (existing apps still work), but emit `deprecationWarning('7.9.0', ...)` pointing at the offending callback by name so users can fix it. Next minor can hard-fail.

Existing `CallbackTest::testProcess` updated to `return true` explicitly. New `testProcessNullReturnIsDeprecated` asserts the deprecation fires and the return value is still `true`.

### 3. `Like::_setEscaper()` — brittle driver detection + sticky cache

Two problems in one block:

- **Detection** was `substr_compare(get_class($driver), 'Sqlserver', -9) === 0`. Any subclassed or wrapped Sqlserver driver (custom App driver class) is misdetected as default.
- **Stickiness**: the resolved class was written back into the filter's config, so a reused filter instance kept the first detected escaper even when the next query ran on a different connection.

Switched to `instanceof` against the driver instance, added a `Postgres` branch with a new `PostgresEscaper` class that currently inherits from `DefaultEscaper` (a stub for now — driver-specific wildcard rules can diverge later without breaking the public API), and removed the `setConfig('escaper', ...)` write-back so each `_setEscaper()` call resolves afresh.

Three regression tests, all using anonymous subclasses of the actual Cake driver classes + a stub connection that injects them (avoids needing a real Postgres/SQL Server server in CI):

- `testEscaperSelectionForSqlServerDriverSubclass`,
- `testEscaperSelectionForPostgresDriver`,
- `testEscaperResolvesAfreshPerQuery`.

## Gates

All green locally: `phpunit` (156 tests, 337 assertions, 2 pre-existing skips), `phpstan` level 8 (clean), `phpcs` (clean).

## Notes

- All three fixes target `master` (CakePHP 5). Suggested release target: `7.9.0` — the Callback deprecation is the only behavior-visible change and naturally fits a minor bump.
- Out of scope (next PR): pluggable escaper resolver — a config knob letting apps register `driver => escaperClass` mappings without subclassing the filter. Builds cleanly on top of the per-query resolution from this PR.
- Also out of scope: `Finder::process()` argument filtering (closed #341), `Value` `IS NULL` support (closed #351), migrating tests to fixture-factories.
