### PR TITLE
Add pluggable escaper resolver for the Like filter

### DIFF
--- a/docs/filters-and-examples.md
+++ b/docs/filters-and-examples.md
@@ -288,12 +288,44 @@ The following options are supported by all filters except `Callback` and `Finder
   (`_`) is being escaped in case used the search term.
 
 - `escaper` (`string`, default to `null`) Defines the escaper that should
-  escape `%` and `_`. If no escaper is set (`escapeDriver => 'null'`) the escaper
-  is set by database driver. If the driver is `Sqlserver` the `SqlserverEscaper`
-  is used (escaping `%` to `[%]` and `_` to `[_]`). In all other cases the
-  `DefaultEscaper` is used (escaping `%` to `\%` and `_` to `\_`). You can add an
-  own escaper by adding a escaper in `App\Model\Filter\Escaper\OwnEscaper` and
-  settings `'escaper' => 'App.Own'`.
+  escape `%` and `_`. If no escaper is set (the default) the escaper is
+  resolved from the active database driver via the `escapers` map (see
+  below). You can pin a specific escaper for a filter by setting this option
+  (e.g. `'escaper' => 'App.Own'`) — the active driver is then ignored.
+
+- `escapers` (`array<string, string>`, defaults to a built-in map) Maps a
+  Cake `Driver` class name to an escaper class spec (Cake plugin-syntax,
+  e.g. `Search.Sqlserver`). Used when `escaper` is left at `null`. The
+  shipped defaults are:
+
+  - `Cake\Database\Driver\Sqlserver::class => 'Search.Sqlserver'`
+  - `Cake\Database\Driver\Postgres::class => 'Search.Postgres'`
+
+  Apps register custom escapers by extending this map at filter setup
+  without needing to subclass the filter:
+
+  ```php
+  use App\Database\Driver\MyMariaDb;
+
+  $searchManager->like('title', [
+      'escapers' => [
+          MyMariaDb::class => 'App.MyMariaDb',
+      ],
+  ]);
+  ```
+
+  Match is done via `instanceof`, so a subclassed driver still resolves
+  correctly. Entries are evaluated in iteration order; list more specific
+  driver classes before less specific ones. When no entry matches the active
+  driver, `Search.Default` is used (escaping `%` to `\%` and `_` to `\_`).
+
+  The default `SqlserverEscaper` escapes `%` to `[%]` and `_` to `[_]`. The
+  default `PostgresEscaper` currently inherits from `DefaultEscaper`; it
+  exists so Postgres-specific rules can diverge in future without breaking
+  the public API.
+
+  Register your own escaper by adding a class in
+  `App\Model\Filter\Escaper\OwnEscaper` implementing `EscaperInterface`.
 
 ### `Value`
 

--- a/src/Model/Filter/Like.php
+++ b/src/Model/Filter/Like.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Search\Model\Filter;
 
 use Cake\Core\App;
+use Cake\Database\Driver;
 use Cake\Database\Driver\Postgres;
 use Cake\Database\Driver\Sqlserver;
 use Cake\ORM\Query\SelectQuery;
@@ -24,6 +25,23 @@ class Like extends Base
     /**
      * Default configuration.
      *
+     * `escapers` maps a Cake database driver class name to an escaper class
+     * spec (Cake plugin-syntax, e.g. `Search.Sqlserver`). It is consulted by
+     * `_setEscaper()` via `instanceof` so a subclassed driver still matches.
+     * Apps register custom escapers by extending this map at filter setup:
+     *
+     * ```php
+     * $searchManager->like('title', [
+     *     'escapers' => [
+     *         App\Database\Driver\MyMariaDb::class => 'App.MyMariaDb',
+     *     ],
+     * ]);
+     * ```
+     *
+     * Entries are evaluated in iteration order; place more specific driver
+     * classes before less specific ones. When no entry matches the active
+     * driver, `Search.Default` is used.
+     *
      * @var array<string, mixed>
      */
     protected array $_defaultConfig = [
@@ -35,6 +53,10 @@ class Like extends Base
         'wildcardAny' => '*',
         'wildcardOne' => '?',
         'escaper' => null,
+        'escapers' => [
+            Sqlserver::class => 'Search.Sqlserver',
+            Postgres::class => 'Search.Postgres',
+        ],
         'colType' => [],
     ];
 
@@ -166,11 +188,7 @@ class Like extends Base
             }
 
             $driver = $query->getConnection()->getDriver();
-            $class = match (true) {
-                $driver instanceof Sqlserver => 'Search.Sqlserver',
-                $driver instanceof Postgres => 'Search.Postgres',
-                default => 'Search.Default',
-            };
+            $class = $this->_resolveEscaperClass($driver);
             // Intentionally NOT caching the resolved class on the filter:
             // re-using the same filter instance against a query backed by a
             // different connection / driver must resolve afresh.
@@ -186,5 +204,31 @@ class Like extends Base
         }
 
         $this->_escaper = new $className($this->getConfig());
+    }
+
+    /**
+     * Resolve the escaper class spec for the given driver instance against
+     * the configured `escapers` map. Falls back to `Search.Default` when no
+     * map entry matches.
+     *
+     * Override this method (or supply a custom `escapers` map) to register
+     * driver-specific escapers without subclassing the filter.
+     *
+     * @param \Cake\Database\Driver $driver Driver instance to resolve against.
+     * @return string Cake plugin-syntax escaper class spec.
+     */
+    protected function _resolveEscaperClass(Driver $driver): string
+    {
+        $escapers = (array)$this->getConfig('escapers');
+        foreach ($escapers as $driverClass => $escaperClass) {
+            if (!is_string($driverClass) || $driverClass === '') {
+                continue;
+            }
+            if ($driver instanceof $driverClass) {
+                return (string)$escaperClass;
+            }
+        }
+
+        return 'Search.Default';
     }
 }

--- a/tests/TestCase/Model/Filter/LikeTest.php
+++ b/tests/TestCase/Model/Filter/LikeTest.php
@@ -488,6 +488,66 @@ class LikeTest extends TestCase
      *
      * @return void
      */
+
+    /**
+     * Apps can register a custom escaper for a driver class via the
+     * `escapers` config map without subclassing the filter. The map is
+     * merged into the defaults at filter construction (Cake's normal
+     * `_defaultConfig` behavior), so existing mappings still apply.
+     *
+     * @return void
+     */
+    public function testCustomEscaperViaEscapersMap()
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $manager = new Manager($articles);
+
+        // The user has a driver subclass and wants to send it to a specific
+        // escaper. Map entries are evaluated in iteration order, so listing
+        // the subclass first overrides the shipped Sqlserver-class default.
+        $driver = new class extends Sqlserver {
+            public function connect(): void
+            {
+            }
+        };
+
+        $filter = new Like('title', $manager, [
+            'escapers' => [
+                $driver::class => 'Search.Default',
+            ],
+        ]);
+        $filter->setArgs(['title' => 'foo']);
+        $this->_invokeSetEscaper($filter, $this->_queryWithDriver($driver));
+
+        $this->assertInstanceOf(
+            DefaultEscaper::class,
+            $this->_resolvedEscaper($filter),
+        );
+    }
+
+    /**
+     * Unknown drivers (not in the escapers map and not in the shipped
+     * defaults) fall through to `Search.Default`.
+     *
+     * @return void
+     */
+    public function testEscaperFallsBackToDefaultWhenNoMatch()
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $manager = new Manager($articles);
+        $filter = new Like('title', $manager, [
+            // Explicitly empty map; no entry will match the sqlite driver.
+            'escapers' => [],
+        ]);
+        $filter->setArgs(['title' => 'foo']);
+        $this->_invokeSetEscaper($filter, $this->_queryWithDriver($articles->getConnection()->getDriver()));
+
+        $this->assertInstanceOf(
+            DefaultEscaper::class,
+            $this->_resolvedEscaper($filter),
+        );
+    }
+
     public function testEscaperResolvesAfreshPerQuery()
     {
         $articles = $this->getTableLocator()->get('Articles');


### PR DESCRIPTION
## Summary

Exposes the Like filter's driver-to-escaper mapping as a config option (`escapers`), so apps register custom escapers for custom or subclassed drivers without subclassing the filter. Builds on the per-query driver resolution from #374.

## API

```php
use App\Database\Driver\MyMariaDb;

$searchManager->like('title', [
    'escapers' => [
        MyMariaDb::class => 'App.MyMariaDb',
    ],
]);
```

The shipped defaults (`Sqlserver::class => 'Search.Sqlserver'`, `Postgres::class => 'Search.Postgres'`) are merged in via Cake's normal `_defaultConfig` behavior, so apps only specify their additions. Match is `instanceof`-based, so a subclassed driver still resolves correctly. Entries are evaluated in iteration order; the first match wins. When nothing matches, `Search.Default` is used.

## Implementation

- Adds `'escapers' => [Sqlserver::class => 'Search.Sqlserver', Postgres::class => 'Search.Postgres']` to `Like::$_defaultConfig`.
- Replaces the in-line driver match in `_setEscaper()` with a new protected hook `_resolveEscaperClass(Driver $driver)` so subclasses can also override the entire resolution policy.
- The `escaper` option still works as before: if set, it pins a specific escaper regardless of the active driver. The new `escapers` option only kicks in when `escaper` is `null` (the default).

## Tests

Two new cases:

- `testCustomEscaperViaEscapersMap` — a driver subclass listed in `escapers` is resolved before the shipped Sqlserver/Postgres defaults, demonstrating the override path.
- `testEscaperFallsBackToDefaultWhenNoMatch` — when the map is explicitly empty and no shipped entry matches the active driver, `Search.Default` is used.

All gates green locally: `phpunit` (158 tests, 340 assertions), `phpstan` level 8 (clean), `phpcs` (clean).

## Docs

`docs/filters-and-examples.md` updated alongside the code: the `escaper` option's description was simplified and a new `escapers` entry was added with a worked example, ordering note, and pointer to the EscaperInterface.

## Dependency

This PR is based on the branch from #374 (extraParams leak, Callback null contract, per-query Like escaper resolution). It will not merge cleanly until #374 is merged or this is rebased onto master after #374 lands.

Recommended order: land #374 first, then rebase this on master and merge.
